### PR TITLE
Added a check for empty routes to prevent crash when mixing shell and hybrid

### DIFF
--- a/samples/ControlGallery/ControlGallery/Views/Index.razor
+++ b/samples/ControlGallery/ControlGallery/Views/Index.razor
@@ -1,7 +1,7 @@
 ﻿@page "/"
 
 <h3>This is a web razor component that could be used in a web view</h3>
-<h3>The page directive will bem picked up by the ShellNavigationManger even though it can't use this page</h3>
+<h3>The page directive will be picked up by the ShellNavigationManger even though it can't use this page</h3>
 <h3>ShellNavigationManager has been updated to ignore this url</h3>
 
 @code {

--- a/samples/ControlGallery/ControlGallery/Views/Index.razor
+++ b/samples/ControlGallery/ControlGallery/Views/Index.razor
@@ -1,0 +1,9 @@
+﻿@page "/"
+
+<h3>This is a web razor component that could be used in a web view</h3>
+<h3>The page directive will bem picked up by the ShellNavigationManger even though it can't use this page</h3>
+<h3>ShellNavigationManager has been updated to ignore this url</h3>
+
+@code {
+
+}

--- a/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
@@ -37,6 +37,8 @@ namespace Microsoft.MobileBlazorBindings
                 var routes = page.GetCustomAttributes<RouteAttribute>();
                 foreach (var route in routes)
                 {
+                    if (route.Template == "/")//This route is needed for Hybrid apps and should be ignore by Shell
+                        continue;
                     if (page.IsSubclassOf(typeof(ComponentBase)))
                     {
                         var structuredRoute = new StructuredRoute(route.Template, page);

--- a/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
@@ -37,8 +37,12 @@ namespace Microsoft.MobileBlazorBindings
                 var routes = page.GetCustomAttributes<RouteAttribute>();
                 foreach (var route in routes)
                 {
-                    if (route.Template == "/")//This route is needed for Hybrid apps and should be ignore by Shell
+                    if (route.Template == "/")
+                    {
+                        // This route can be used in Hybrid apps and should be ignored by Shell (because Shell doesn't support empty routes anyway)
                         continue;
+                    }
+
                     if (page.IsSubclassOf(typeof(ComponentBase)))
                     {
                         var structuredRoute = new StructuredRoute(route.Template, page);


### PR DESCRIPTION

Added a check so that ShellNavigationManager ignores "/" and continues.
Added a sample razor file that would cause crash if not fixed and now works fine.