### PR TITLE
Add RequireHttpsMetadata to ProviderOptions to allow modify Discovery policy RequireHttps value

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.Authentication/Options/OidcProviderOptions.cs
+++ b/src/Microsoft.MobileBlazorBindings.Authentication/Options/OidcProviderOptions.cs
@@ -62,5 +62,10 @@ namespace Microsoft.MobileBlazorBindings.Authentication
         /// </summary>
         [JsonPropertyName("response_mode")]
         public string ResponseMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether require https for request metadata.
+        /// </summary>
+        public bool RequireHttpsMetadata { get; set; } = true;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.Authentication/Services/OidcAuthenticationService.cs
+++ b/src/Microsoft.MobileBlazorBindings.Authentication/Services/OidcAuthenticationService.cs
@@ -313,16 +313,19 @@ namespace Microsoft.MobileBlazorBindings.Authentication
                 throw new OptionsValidationException("ResponseMode", typeof(OidcProviderOptions), new string[] { $"{oidcProviderOptions.ResponseMode} is not a valid response mode." });
             }
 
-            return new OidcClient(new OidcClientOptions()
-            {
-                Authority = oidcProviderOptions.Authority,
-                ClientId = oidcProviderOptions.ClientId,
-                PostLogoutRedirectUri = oidcProviderOptions.PostLogoutRedirectUri,
-                RedirectUri = oidcProviderOptions.RedirectUri,
-                ResponseMode = responseMode,
-                LoadProfile = false,
-                Scope = string.Join(" ", oidcProviderOptions.DefaultScopes),
-            });
+            var oidcClientOptions = new OidcClientOptions
+                                    {
+                                        Authority = oidcProviderOptions.Authority,
+                                        ClientId = oidcProviderOptions.ClientId,
+                                        PostLogoutRedirectUri = oidcProviderOptions.PostLogoutRedirectUri,
+                                        RedirectUri = oidcProviderOptions.RedirectUri,
+                                        ResponseMode = responseMode,
+                                        LoadProfile = false,
+                                        Scope = string.Join(" ", oidcProviderOptions.DefaultScopes),
+                                    };
+
+            oidcClientOptions.Policy.Discovery.RequireHttps = oidcProviderOptions.RequireHttpsMetadata;
+            return new OidcClient(oidcClientOptions);
         }
 
         /// <summary>


### PR DESCRIPTION
Sample of usage
    
    services.AddOidcAuthentication(
                            options =>
                                {
                                    /*...*/
                                    options.ProviderOptions.RequireHttpsMetadata = false;
                                    /*...*/
                                });

This is a fix for this #321 
