### PR TITLE
Fix Shell navigation crash if another navigation is in progress 

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHost.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHost.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.MobileBlazorBindings.Hosting;
 
@@ -14,11 +13,6 @@ namespace Microsoft.MobileBlazorBindings
             var builder = BlazorWebHost.CreateDefaultBuilder(args);
 
             EnableStyleSheetSupport();
-
-            builder.ConfigureServices(serviceCollection =>
-            {
-                serviceCollection.AddSingleton<MobileBlazorBindingsRenderer>();
-            });
 
             return builder;
         }

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHostExtensions.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHostExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.MobileBlazorBindings.Elements.Handlers;
 using System;
 using System.Threading.Tasks;
@@ -32,7 +33,10 @@ namespace Microsoft.MobileBlazorBindings
             }
 
             var services = host.Services;
-            var renderer = services.GetRequiredService<MobileBlazorBindingsRenderer>();
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var renderer = new MobileBlazorBindingsRenderer(services, services.GetRequiredService<ILoggerFactory>());
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
             // TODO: This call is an async call, but is called as "fire-and-forget," which is not ideal.
             // We need to figure out how to get Xamarin.Forms to run this startup code asynchronously, which
@@ -65,7 +69,9 @@ namespace Microsoft.MobileBlazorBindings
                 throw new InvalidOperationException($"Cannot add {type.Name} to {parent.GetType().Name}. {type.Name} is not an IComponent. If you are trying to add a Xamarin.Forms type, try adding the Mobile Blazor Bindings equivalent instead.");
             }
 
-            var renderer = services.GetRequiredService<MobileBlazorBindingsRenderer>();
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var renderer = new MobileBlazorBindingsRenderer(services, services.GetRequiredService<ILoggerFactory>());
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
             return await renderer.AddComponent(type, CreateHandler(parent, renderer), parameters).ConfigureAwait(false);
         }

--- a/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.MobileBlazorBindings.Elements.Handlers;
 using Microsoft.MobileBlazorBindings.ShellNavigation;
 using System;
@@ -96,7 +97,11 @@ namespace Microsoft.MobileBlazorBindings
         {
             var container = new RootContainerHandler();
             var route = NavigationParameters[componentType];
-            var renderer = _services.GetRequiredService<MobileBlazorBindingsRenderer>();
+
+            var loggerFactory = _services.GetRequiredService<ILoggerFactory>();
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var renderer = new MobileBlazorBindingsRenderer(_services, loggerFactory);
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
             var addComponentTask = renderer.AddComponent(componentType, container, route.Parameters);
             var elementAddedTask = container.WaitForElementAsync();


### PR DESCRIPTION
Fixes #302 .

I reverted back adding MobileBlazorBindingsRenderer as a singleton to serviceCollection.
I dispose renderers created during Shell navigation when rendered Page disappears from NavigationStack(s).




In order to verify that this fix works, you can add the following code to NavigationSource.razor:
```csharp
    protected override async Task OnInitializedAsync()
    {
        await NavigateNoParameter();
    }
```
And verify that navigation happens successfully on "Navigation playground" button click in ControlGallery sample. 
You can also try double clicking (really fast) that button, app crashed before as well sometimes.
You can also add `@implements IDisposable` with empty implementation, and verify that it's called appropriately.