### PR TITLE
Add Page.ToolbarItems property support

### DIFF
--- a/samples/ControlGallery/ControlGallery/Views/ShellPropertiesPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/ShellPropertiesPlayground.razor
@@ -1,35 +1,48 @@
-﻿<ContentPage Title="Shell Properties">
-    <ShellProperties NavBarIsVisible="navBarVisible"
-                     TabBarIsVisible="tabBarVisible"
-                     TitleColor="titleColor" />
+﻿<ContentPage @ref="page">
+    <ToolbarItems>
+        <ToolbarItem Text="Help" OnClick="ShowHelp" />
+    </ToolbarItems>
 
-    <StackLayout>
-        <StackLayout Orientation="StackOrientation.Horizontal">
-            <Label Text="Enable NavBar: " />
-            <CheckBox @bind-IsChecked="navBarVisible" />
+    <ChildContent>
+        <ShellProperties NavBarIsVisible="navBarVisible"
+                         TabBarIsVisible="tabBarVisible"
+                         TitleColor="titleColor" />
+
+        <StackLayout>
+            <StackLayout Orientation="StackOrientation.Horizontal">
+                <Label Text="Enable NavBar: " />
+                <CheckBox @bind-IsChecked="navBarVisible" />
+            </StackLayout>
+            <StackLayout Orientation="StackOrientation.Horizontal">
+                <Label Text="Enable TabBar: " />
+                <CheckBox @bind-IsChecked="tabBarVisible" />
+            </StackLayout>
+            <Button Text="Change Title Color" OnClick="ChangeTitleColor" />
         </StackLayout>
-        <StackLayout Orientation="StackOrientation.Horizontal">
-            <Label Text="Enable TabBar: " />
-            <CheckBox @bind-IsChecked="tabBarVisible" />
-        </StackLayout>
-        <Button Text="Change Title Color" OnClick="ChangeTitleColor" />
-    </StackLayout>
+    </ChildContent>
 </ContentPage>
 
 @code{
+    Microsoft.MobileBlazorBindings.Elements.Page page;
+
     bool navBarVisible = true;
     bool tabBarVisible = true;
     Color? titleColor;
 
     List<Color> colors = new List<Color> {
-        Color.Red,
-        Color.Green,
-        Color.Blue
+    Color.Red,
+    Color.Green,
+    Color.Blue
     };
 
     void ChangeTitleColor()
     {
         var index = (titleColor.HasValue ? colors.IndexOf(titleColor.Value) + 1 : 0) % colors.Count;
         titleColor = colors[index];
+    }
+
+    async Task ShowHelp()
+    {
+        await page.NativeControl.DisplayAlert("Help", "Some help message", "OK");
     }
 }

--- a/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
+++ b/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
@@ -116,6 +116,8 @@ namespace ComponentWrapperGenerator
         {{
             ElementHandlerRegistry.RegisterElementHandler<{componentName}>(
                 renderer => new {componentHandlerName}(renderer, new {componentNamespacePrefix}{componentName}()));
+
+            RegisterAdditionalHandlers();
         }}
 ";
             }
@@ -140,6 +142,8 @@ namespace {Settings.RootNamespace}
         }}
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }}
 }}
 ");

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -49,6 +49,7 @@ TabbedPage
 TemplatedPage
 TemplatedView
 TimePicker
+ToolbarItem
 View
 VisualElement
 

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerRegistry.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerRegistry.cs
@@ -23,6 +23,13 @@ namespace Microsoft.MobileBlazorBindings.Core
             ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory((renderer, _) => factory(renderer)));
         }
 
+        public static void RegisterPropertyContentHandler<TComponent>(string propertyName,
+            Func<NativeComponentRenderer, IElementHandler> factory) where TComponent : NativeControlComponentBase
+        {
+            var key = $"p-{typeof(TComponent).FullName}.{propertyName}";
+            ElementHandlers.Add(key, new ElementHandlerFactory((renderer, _) => factory(renderer)));
+        }
+
         public static void RegisterElementHandler<TComponent, TControlHandler>() where TComponent : NativeControlComponentBase where TControlHandler : class, IElementHandler, new()
         {
             RegisterElementHandler<TComponent>((_, __) => new TControlHandler());

--- a/src/Microsoft.MobileBlazorBindings.Core/NativeControlComponentBase.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/NativeControlComponentBase.cs
@@ -32,10 +32,17 @@ namespace Microsoft.MobileBlazorBindings.Core
                 builder.AddContent(2, childContent);
             }
 
+            int sequence = 3;
+            RenderAdditionalElementContent(builder, ref sequence);
+
             builder.CloseElement();
         }
 
         protected virtual void RenderAttributes(AttributesBuilder builder)
+        {
+        }
+
+        protected virtual void RenderAdditionalElementContent(RenderTreeBuilder builder, ref int sequence)
         {
         }
 

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.generated.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TwoPaneView>(
                 renderer => new TwoPaneViewHandler(renderer, new XFD.TwoPaneView()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? MinTallModeHeight { get; set; }
@@ -65,5 +67,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ActivityIndicator.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ActivityIndicator.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ActivityIndicator>(
                 renderer => new ActivityIndicatorHandler(renderer, new XF.ActivityIndicator()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseMenuItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseMenuItem.generated.cs
@@ -23,5 +23,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<BaseShellItem>(
                 renderer => new BaseShellItemHandler(renderer, new XF.BaseShellItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -116,5 +118,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BoxView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BoxView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<BoxView>(
                 renderer => new BoxViewHandler(renderer, new XF.BoxView()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Button.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Button.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Button>(
                 renderer => new ButtonHandler(renderer, new XF.Button()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -137,5 +139,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<CheckBox>(
                 renderer => new CheckBoxHandler(renderer, new XF.CheckBox()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.Color? Color { get; set; }
@@ -39,5 +41,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ContentPage>(
                 renderer => new ContentPageHandler(renderer, new XF.ContentPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ContentPage NativeControl => ((ContentPageHandler)ElementHandler).ContentPageControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ContentView>(
                 renderer => new ContentViewHandler(renderer, new XF.ContentView()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ContentView NativeControl => ((ContentViewHandler)ElementHandler).ContentViewControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/DatePicker.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/DatePicker.generated.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<DatePicker>(
                 renderer => new DatePickerHandler(renderer, new XF.DatePicker()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? CharacterSpacing { get; set; }
@@ -119,5 +121,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Entry.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Entry.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Entry>(
                 renderer => new EntryHandler(renderer, new XF.Entry()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.ClearButtonVisibility? ClearButtonVisibility { get; set; }
@@ -126,5 +128,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/FlyoutItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FlyoutItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<FlyoutItem>(
                 renderer => new FlyoutItemHandler(renderer, new XF.FlyoutItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.FlyoutItem NativeControl => ((FlyoutItemHandler)ElementHandler).FlyoutItemControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/FlyoutPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FlyoutPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<FlyoutPage>(
                 renderer => new FlyoutPageHandler(renderer, new XF.FlyoutPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.FlyoutLayoutBehavior? FlyoutLayoutBehavior { get; set; }
@@ -44,5 +46,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Frame.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Frame.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Frame>(
                 renderer => new FrameHandler(renderer, new XF.Frame()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -59,5 +61,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/GestureElement.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/GestureElement.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<GestureElement>(
                 renderer => new GestureElementHandler(renderer, new XF.GestureElement()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.GestureElement NativeControl => ((GestureElementHandler)ElementHandler).GestureElementControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Grid.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Grid.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Grid>(
                 renderer => new GridHandler(renderer, new XF.Grid()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ListContentPropertyHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ListContentPropertyHandler.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using System.Collections.Generic;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class ListContentPropertyHandler<TElementType, TItemType> : IXamarinFormsContainerElementHandler, INonChildContainerElement where TItemType : XF.Element
+    {
+        private readonly Func<TElementType, IList<TItemType>> _listPropertyAccessor;
+        private IList<TItemType> _propertyItems;
+
+        public ListContentPropertyHandler(Func<TElementType, IList<TItemType>> listPropertyAccessor)
+        {
+            _listPropertyAccessor = listPropertyAccessor;
+        }
+
+        public void SetParent(object parentElement)
+        {
+            _propertyItems = _listPropertyAccessor((TElementType)parentElement);
+        }
+
+        void IXamarinFormsContainerElementHandler.AddChild(XF.Element child, int physicalSiblingIndex)
+        {
+            if (!(child is TItemType typedChild))
+            {
+                throw new NotSupportedException($"Cannot add item of type {child?.GetType().Name} to a {typeof(TItemType)} collection.");
+            }
+
+            _propertyItems.Insert(physicalSiblingIndex, typedChild);
+        }
+
+        int IXamarinFormsContainerElementHandler.GetChildIndex(XF.Element child)
+        {
+            return _propertyItems.IndexOf(child as TItemType);
+        }
+
+        void IXamarinFormsContainerElementHandler.RemoveChild(XF.Element child)
+        {
+            _propertyItems.Remove(child as TItemType);
+        }
+
+        // Because this is a 'fake' element, all matters related to physical trees
+        // should be no-ops.
+
+        object IElementHandler.TargetElement => null;
+        void IElementHandler.ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName) { }
+
+        XF.Element IXamarinFormsElementHandler.ElementControl => null;
+        bool IXamarinFormsElementHandler.IsParented() => false;
+        bool IXamarinFormsElementHandler.IsParentedTo(XF.Element parent) => false;
+
+        void IXamarinFormsElementHandler.SetParent(XF.Element parent)
+        {
+            // This should never get called. Instead, INonChildContainerElement.SetParent() implemented
+            // in this class should get called.
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ToolbarItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ToolbarItemHandler.generated.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class ToolbarItemHandler : MenuItemHandler
+    {
+
+        public ToolbarItemHandler(NativeComponentRenderer renderer, XF.ToolbarItem toolbarItemControl) : base(renderer, toolbarItemControl)
+        {
+            ToolbarItemControl = toolbarItemControl ?? throw new ArgumentNullException(nameof(toolbarItemControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XF.ToolbarItem ToolbarItemControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.ToolbarItem.Order):
+                    ToolbarItemControl.Order = (XF.ToolbarItemOrder)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ToolbarItem.Priority):
+                    ToolbarItemControl.Priority = AttributeHelper.GetInt(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Image.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Image.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Image>(
                 renderer => new ImageHandler(renderer, new XF.Image()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -67,5 +69,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ImageButton>(
                 renderer => new ImageButtonHandler(renderer, new XF.ImageButton()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.Aspect? Aspect { get; set; }
@@ -64,5 +66,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/InputView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/InputView.generated.cs
@@ -125,5 +125,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Label.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Label.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Label>(
                 renderer => new LabelHandler(renderer, new XF.Label()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? CharacterSpacing { get; set; }
@@ -155,5 +157,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Layout.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Layout.generated.cs
@@ -57,5 +57,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<MenuItem>(
                 renderer => new MenuItemHandler(renderer, new XF.MenuItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public string @class { get; set; }
@@ -74,5 +76,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.generated.cs
@@ -34,5 +34,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
@@ -2,12 +2,21 @@
 // Licensed under the MIT license.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public partial class Page : VisualElement
     {
+        static partial void RegisterAdditionalHandlers()
+        {
+            ElementHandlerRegistry.RegisterPropertyContentHandler<Page>(nameof(ToolbarItems),
+                _ => new ListContentPropertyHandler<XF.Page, XF.ToolbarItem>(page => page.ToolbarItems));
+        }
+
         /// <summary>
         /// Indicates that the <see cref="Xamarin.Forms.Page" /> is about to appear.
         /// </summary>
@@ -18,11 +27,18 @@ namespace Microsoft.MobileBlazorBindings.Elements
         /// </summary>
         [Parameter] public EventCallback OnDisappearing { get; set; }
 
+        [Parameter] public RenderFragment ToolbarItems { get; set; }
+
 #pragma warning disable CA1721 // Property names should not match get methods
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
         protected override RenderFragment GetChildContent() => ChildContent;
+
+        protected override void RenderAdditionalElementContent(RenderTreeBuilder builder, ref int sequence)
+        {
+            RenderTreeBuilderHelper.AddContentProperty(builder, sequence++, typeof(Page), nameof(ToolbarItems), ToolbarItems);
+        }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Page>(
                 renderer => new PageHandler(renderer, new XF.Page()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.ImageSource BackgroundImageSource { get; set; }
@@ -66,5 +68,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ProgressBar.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ProgressBar.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ProgressBar>(
                 renderer => new ProgressBarHandler(renderer, new XF.ProgressBar()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/PropertyWrapperComponent.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/PropertyWrapperComponent.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    /// <summary>
+    /// The only purpose of this type is to wrap content property handler, since currently renderer does not allow 
+    /// handlers without corresponding component.
+    /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Class is used generically.
+    internal class PropertyWrapperComponent : NativeControlComponentBase
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            ChildContent(builder);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ScrollView>(
                 renderer => new ScrollViewHandler(renderer, new XF.ScrollView()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -59,5 +61,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Shell.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Shell.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Shell>(
                 renderer => new ShellHandler(renderer, new XF.Shell()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -97,5 +99,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellContent>(
                 renderer => new ShellContentHandler(renderer, new XF.ShellContent()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ShellContent NativeControl => ((ShellContentHandler)ElementHandler).ShellContentControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellGroupItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellGroupItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellGroupItem>(
                 renderer => new ShellGroupItemHandler(renderer, new XF.ShellGroupItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -37,5 +39,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellItem>(
                 renderer => new ShellItemHandler(renderer, new XF.ShellItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ShellItem NativeControl => ((ShellItemHandler)ElementHandler).ShellItemControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellSection>(
                 renderer => new ShellSectionHandler(renderer, new XF.ShellSection()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ShellSection NativeControl => ((ShellSectionHandler)ElementHandler).ShellSectionControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Slider.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Slider.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Slider>(
                 renderer => new SliderHandler(renderer, new XF.Slider()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -100,5 +102,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Span.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Span.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Span>(
                 renderer => new SpanHandler(renderer, new XF.Span()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -114,5 +116,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<StackLayout>(
                 renderer => new StackLayoutHandler(renderer, new XF.StackLayout()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Stepper.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Stepper.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Stepper>(
                 renderer => new StepperHandler(renderer, new XF.Stepper()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -73,5 +75,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Switch.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Switch.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Switch>(
                 renderer => new SwitchHandler(renderer, new XF.Switch()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -53,5 +55,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Tab.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Tab.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Tab>(
                 renderer => new TabHandler(renderer, new XF.Tab()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.Tab NativeControl => ((TabHandler)ElementHandler).TabControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TabBar.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TabBar.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TabBar>(
                 renderer => new TabBarHandler(renderer, new XF.TabBar()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.TabBar NativeControl => ((TabBarHandler)ElementHandler).TabBarControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TabbedPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TabbedPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TabbedPage>(
                 renderer => new TabbedPageHandler(renderer, new XF.TabbedPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -61,5 +63,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TemplatedPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TemplatedPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TemplatedPage>(
                 renderer => new TemplatedPageHandler(renderer, new XF.TemplatedPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.TemplatedPage NativeControl => ((TemplatedPageHandler)ElementHandler).TemplatedPageControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TemplatedView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TemplatedView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TemplatedView>(
                 renderer => new TemplatedViewHandler(renderer, new XF.TemplatedView()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.TemplatedView NativeControl => ((TemplatedViewHandler)ElementHandler).TemplatedViewControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TimePicker.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TimePicker.generated.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TimePicker>(
                 renderer => new TimePickerHandler(renderer, new XF.TimePicker()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? CharacterSpacing { get; set; }
@@ -97,5 +99,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ToolbarItem : MenuItem
+    {
+        static ToolbarItem()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<ToolbarItem>(
+                renderer => new ToolbarItemHandler(renderer, new XF.ToolbarItem()));
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates on which of the primary, secondary, or default toolbar surfaces to display this <see cref="T:Xamarin.Forms.ToolbarItem" /> element.
+        /// </summary>
+        [Parameter] public XF.ToolbarItemOrder? Order { get; set; }
+        /// <summary>
+        /// Gets or sets the priority of this <see cref="T:Xamarin.Forms.ToolbarItem" /> element.
+        /// </summary>
+        [Parameter] public int? Priority { get; set; }
+
+        public new XF.ToolbarItem NativeControl => ((ToolbarItemHandler)ElementHandler).ToolbarItemControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (Order != null)
+            {
+                builder.AddAttribute(nameof(Order), (int)Order.Value);
+            }
+            if (Priority != null)
+            {
+                builder.AddAttribute(nameof(Priority), Priority.Value);
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ToolbarItem>(
                 renderer => new ToolbarItemHandler(renderer, new XF.ToolbarItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -45,5 +47,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/View.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/View.generated.cs
@@ -54,5 +54,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.generated.cs
@@ -260,5 +260,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/RenderTreeBuilderHelper.cs
+++ b/src/Microsoft.MobileBlazorBindings/RenderTreeBuilderHelper.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.MobileBlazorBindings.Elements;
+using System;
+
+namespace Microsoft.MobileBlazorBindings
+{
+    public static class RenderTreeBuilderHelper
+    {
+        public static void AddContentProperty(RenderTreeBuilder builder, int sequence, Type containingType, string propertyName, RenderFragment content)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (content != null)
+            {
+                builder.OpenRegion(sequence);
+
+                // Content properties are handled by separate handlers, there rendered as separate child elements.
+                // Renderer does not support elements without parent components as for now,
+                // therefore adding empty parent component to workaround that.
+                builder.OpenComponent<PropertyWrapperComponent>(0);
+                builder.AddAttribute(1, "ChildContent", (RenderFragment)(builder =>
+                {
+                    builder.OpenElement(2, $"p-{containingType.FullName}.{propertyName}");
+                    builder.AddContent(3, content);
+                    builder.CloseElement();
+                }));
+                builder.CloseComponent();
+
+                builder.CloseRegion();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #342  .

PR has two commits, I suggest reviewing them one-by-one. Most of interesting changes are in the first one, second only contains some generator updates and regenerated components.

<details>
<summary>Example .razor</summary>

```razor
<ContentPage @ref="page">
    <ToolbarItems>
        <ToolbarItem Text="Help" OnClick="ShowHelp" />
    </ToolbarItems>

    <ChildContent>
// actual page content
    </ChildContent>
</ContentPage>

@code {
    Microsoft.MobileBlazorBindings.Elements.Page page;

    async Task ShowHelp()
    {
        await page.NativeControl.DisplayAlert("Help", "Some help message", "OK");
    }
}
```

</details>

<details>
<summary>Screen
</summary>

![ItRjsAHlBk](https://user-images.githubusercontent.com/17177729/110335160-39b4d200-802c-11eb-8e71-c6edac22f11a.gif)

</details>

The main challenge with this property is how to render multiple content "children" (actual ChildContent and property content).
I decided to have a separate handler for this property (ListContentPropertyHandler), which sets the content for parent page (similar to what we have with GridCellHandler).
Component renders this property as a separate child element.

Note that while ListContentPropertyHandler has no corresponding component, I had to add a fake one (PropertyWrapperComponent), because our rendered does not really like multiple elements with same parent component.

Not sure how clear is that, but feel free to ask any questions :)