### PR TITLE
Performance improvement for AttributeValueHolder delegate

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/AttributeValueHolder.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/AttributeValueHolder.cs
@@ -9,6 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
     /// the data is wrapped in a delegate of this type, which can contain logic to return and type.
     /// Then the handler invokes that delegate to retrieve the original data.
     /// </summary>
-    /// <param name="value">The data that this delegate represents.</param>
-    public delegate void AttributeValueHolder(out object value);
+    /// <returns>The data that this delegate represents.</returns>
+    public delegate object AttributeValueHolder();
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/AttributeValueHolderFactory.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/AttributeValueHolderFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.MobileBlazorBindings.Extensions;
 using System;
 
 namespace Microsoft.MobileBlazorBindings.Elements
@@ -11,21 +12,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
     /// </summary>
     public static class AttributeValueHolderFactory
     {
-        private sealed class DataHolder<TAttributeValue>
-        {
-            private readonly TAttributeValue _attributeValue;
-
-            internal DataHolder(TAttributeValue attributeValue)
-            {
-                _attributeValue = attributeValue;
-            }
-
-            internal void ProduceValue(out object attributeValue)
-            {
-                attributeValue = _attributeValue;
-            }
-        }
-
         /// <summary>
         /// Returns an <see cref="AttributeValueHolder"/> representing the data provided in <paramref name="attributeValue"/>.
         /// </summary>
@@ -34,7 +20,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
         /// <returns></returns>
         public static AttributeValueHolder FromObject<TAttributeValue>(TAttributeValue attributeValue)
         {
-            return new AttributeValueHolder(new DataHolder<TAttributeValue>(attributeValue).ProduceValue);
+            // Creating delegate from extension method parameter preserves equality for delegate,
+            // i.e. two delegates are equal if held values are equal.
+            return attributeValue.This;
         }
 
         /// <summary>
@@ -56,7 +44,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 throw new ArgumentException("Expected parameter instance to be an attribute value holder.", nameof(attributeValue));
             }
 
-            attributeValueAsValueHolder(out var value);
+            var value = attributeValueAsValueHolder();
 
             if (!(value is TAttributeValue typedAttributeValue))
             {

--- a/src/Microsoft.MobileBlazorBindings/Extensions/ObjectExtensions.cs
+++ b/src/Microsoft.MobileBlazorBindings/Extensions/ObjectExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.MobileBlazorBindings.Extensions
+{
+    internal static class ObjectExtensions
+    {
+        /// <summary>
+        /// The only purpose of this method it to use it as delegate parameter.
+        /// </summary>
+        public static object This(this object @this) => @this;
+    }
+}


### PR DESCRIPTION
While working on CollectionView I realized, that our approach with AttributeValueHolder approach has an issue - created delegates are not considered equal for same value, therefore Blazor considers those attribute values as changed on each component update.
I've created an extension method This, which simply returns 'this' parameter, and create a delegate from method parameter. Delegates created in such way are considered equal for same objects, and Blazor does not re-render same attributes over and over again, yuy!

It also resolves some issues with infinite loops with binded values.