### PR TITLE
Add CollectionView support

### DIFF
--- a/samples/ControlGallery/ControlGallery/Views/CollectionView/AddRemovePlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CollectionView/AddRemovePlayground.razor
@@ -1,0 +1,44 @@
+﻿@using System.Collections.ObjectModel
+
+<ContentPage Title="Add/Remove">
+    <StackLayout>
+        <Button Text="Add" OnClick="Add" />
+        <Button Text="Remove selected" OnClick="Remove" />
+        <Button Text="Remove all" OnClick="RemoveAll" />
+
+        <CollectionView ItemsSource="_intItems"
+                        SelectionMode="SelectionMode.Single"
+                        @bind-SelectedItem="_selectedItem">
+            <EmptyView>
+                <Label Text="Nothing here." />
+            </EmptyView>
+
+            <ItemTemplate>
+                <Item Value="@context" />
+            </ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</ContentPage>
+
+@code {
+    ObservableCollection<int> _intItems = new ObservableCollection<int>(Enumerable.Range(1, 100));
+    object _selectedItem;
+
+    void Add()
+    {
+        _intItems.Add(_intItems.LastOrDefault() + 1);
+    }
+
+    void Remove()
+    {
+        if (_selectedItem is int selectedInt)
+        {
+            _intItems.Remove(selectedInt);
+        }
+    }
+
+    void RemoveAll()
+    {
+        _intItems.Clear();
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Views/CollectionView/GridLayoutPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CollectionView/GridLayoutPlayground.razor
@@ -1,0 +1,15 @@
+﻿<ContentPage Title="Grid Layout">
+    <CollectionView ItemsSource="_intItems"
+                    SelectionMode="SelectionMode.Single"
+                    ItemsLayout="_itemsLayout">
+
+        <ItemTemplate>
+            <Item Value="@context" />
+        </ItemTemplate>
+    </CollectionView>
+</ContentPage>
+
+@code {
+    IItemsLayout _itemsLayout = new GridItemsLayout(5, ItemsLayoutOrientation.Vertical);
+    List<int> _intItems = Enumerable.Range(1, 100).ToList();
+}

--- a/samples/ControlGallery/ControlGallery/Views/CollectionView/InfiniteScrollPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CollectionView/InfiniteScrollPlayground.razor
@@ -1,0 +1,43 @@
+﻿@using System.Collections.ObjectModel
+
+<ContentPage Title="Infinite scroll">
+    <StackLayout>
+        <CollectionView ItemsSource="_intItems"
+                        RemainingItemsThreshold="2"
+                        OnRemainingItemsThresholdReached="LoadItems">
+            <Header>
+                <Label Text="Scroll to load more items." />
+            </Header>
+
+            <ItemTemplate>
+                <Item Value="@context" />
+            </ItemTemplate>
+
+            <Footer>
+                <ActivityIndicator IsRunning="_loading" />
+            </Footer>
+        </CollectionView>
+    </StackLayout>
+</ContentPage>
+
+@code {
+    ObservableCollection<int> _intItems = new ObservableCollection<int>(Enumerable.Range(1, 20));
+    bool _loading;
+
+    async Task LoadItems()
+    {
+        if (!_loading)
+        {
+            _loading = true;
+
+            await Task.Delay(1000);
+
+            foreach (var item in Enumerable.Range(_intItems.Max() + 1, 20))
+            {
+                _intItems.Add(item);
+            }
+
+            _loading = false;
+        }
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Views/CollectionView/Item.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CollectionView/Item.razor
@@ -1,0 +1,15 @@
+﻿<Frame BackgroundColor="Color.Gray" 
+       CornerRadius="5" 
+       Margin="5" 
+       HeightRequest="24"
+       WidthRequest="24"
+       HorizontalOptions="LayoutOptions.Center">
+
+    <Label Text="@Value.ToString()"
+           VerticalOptions="LayoutOptions.Center"
+           HorizontalOptions="LayoutOptions.Center" />
+</Frame>
+
+@code {
+    [Parameter] public int Value { get; set; }
+}

--- a/samples/ControlGallery/ControlGallery/Views/CollectionView/SelectionPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CollectionView/SelectionPlayground.razor
@@ -1,0 +1,29 @@
+﻿<ContentPage Title="Selection">
+    <StackLayout>
+        <Button Text="Select Random" OnClick="SelectRandom" />
+
+        <Label Text=@($"Selected Items: {(_selectedItems == null ? "" : string.Join(", ", _selectedItems))}") />
+
+        <CollectionView ItemsSource="_intItems"
+                        SelectionMode="SelectionMode.Multiple"
+                        @bind-SelectedItems="_selectedItems">
+            <ItemTemplate>
+                <Item Value="@context" />
+            </ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</ContentPage>
+
+@code {
+    Random _random = new Random();
+    List<int> _intItems = Enumerable.Range(1, 100).ToList();
+    IList<object> _selectedItems;
+
+    void SelectRandom()
+    {
+        _selectedItems = _selectedItems ?? new List<object>();
+
+        _selectedItems.Clear();
+        _selectedItems.Add(_random.Next(1, 10));
+    }
+}

--- a/samples/ControlGallery/ControlGallery/Views/CollectionViewPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CollectionViewPlayground.razor
@@ -1,0 +1,10 @@
+﻿@using ControlGallery.Views.CollectionView
+
+@page "/collectionviewplayground"
+
+<TabbedPage>
+    <SelectionPlayground />
+    <GridLayoutPlayground />
+    <AddRemovePlayground />
+    <InfiniteScrollPlayground />
+</TabbedPage>

--- a/samples/ControlGallery/ControlGallery/Views/PlaygroundList.razor
+++ b/samples/ControlGallery/ControlGallery/Views/PlaygroundList.razor
@@ -10,6 +10,7 @@
             <Button Text="Gesture playground" OnClick="@(async () => await NavigationManager.NavigateToAsync("/gestureplayground"))"></Button>
             <Button Text="Skia Playground" OnClick="@(async () => await NavigationManager.NavigateToAsync("/skia"))"></Button>
             <Button Text="Picker Playground" OnClick="@(async () => await NavigationManager.NavigateToAsync("/pickerplayground"))"></Button>
+            <Button Text="CollectionView Playground" OnClick="@(async () => await NavigationManager.NavigateToAsync("/collectionviewplayground"))"></Button>
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/samples/ControlGallery/ControlGallery/Views/ShellPropertiesPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/ShellPropertiesPlayground.razor
@@ -1,35 +1,48 @@
-﻿<ContentPage Title="Shell Properties">
-    <ShellProperties NavBarIsVisible="navBarVisible"
-                     TabBarIsVisible="tabBarVisible"
-                     TitleColor="titleColor" />
+﻿<ContentPage @ref="page">
+    <ToolbarItems>
+        <ToolbarItem Text="Help" OnClick="ShowHelp" />
+    </ToolbarItems>
 
-    <StackLayout>
-        <StackLayout Orientation="StackOrientation.Horizontal">
-            <Label Text="Enable NavBar: " />
-            <CheckBox @bind-IsChecked="navBarVisible" />
+    <ChildContent>
+        <ShellProperties NavBarIsVisible="navBarVisible"
+                         TabBarIsVisible="tabBarVisible"
+                         TitleColor="titleColor" />
+
+        <StackLayout>
+            <StackLayout Orientation="StackOrientation.Horizontal">
+                <Label Text="Enable NavBar: " />
+                <CheckBox @bind-IsChecked="navBarVisible" />
+            </StackLayout>
+            <StackLayout Orientation="StackOrientation.Horizontal">
+                <Label Text="Enable TabBar: " />
+                <CheckBox @bind-IsChecked="tabBarVisible" />
+            </StackLayout>
+            <Button Text="Change Title Color" OnClick="ChangeTitleColor" />
         </StackLayout>
-        <StackLayout Orientation="StackOrientation.Horizontal">
-            <Label Text="Enable TabBar: " />
-            <CheckBox @bind-IsChecked="tabBarVisible" />
-        </StackLayout>
-        <Button Text="Change Title Color" OnClick="ChangeTitleColor" />
-    </StackLayout>
+    </ChildContent>
 </ContentPage>
 
 @code{
+    Microsoft.MobileBlazorBindings.Elements.Page page;
+
     bool navBarVisible = true;
     bool tabBarVisible = true;
     Color? titleColor;
 
     List<Color> colors = new List<Color> {
-        Color.Red,
-        Color.Green,
-        Color.Blue
+    Color.Red,
+    Color.Green,
+    Color.Blue
     };
 
     void ChangeTitleColor()
     {
         var index = (titleColor.HasValue ? colors.IndexOf(titleColor.Value) + 1 : 0) % colors.Count;
         titleColor = colors[index];
+    }
+
+    async Task ShowHelp()
+    {
+        await page.NativeControl.DisplayAlert("Help", "Some help message", "OK");
     }
 }

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/AppShell.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/AppShell.razor
@@ -1,6 +1,6 @@
 ﻿<Shell OnNavigated="OnNavigated"
        OnNavigating="OnNavigating"
-       FlyoutBackgroundImage="@(new FileImageSource { File = "photo.jpg" })"
+       FlyoutBackgroundImage="@Photo"
        FlyoutBackgroundImageAspect="Aspect.AspectFill"
        FlyoutHeaderBehavior="FlyoutHeaderBehavior.CollapseOnScroll">
     <FlyoutHeader>
@@ -13,56 +13,67 @@
                     FlyoutDisplayOptions="FlyoutDisplayOptions.AsMultipleItems">
             <Tab Title="Domestic"
                  Route="domestic"
-                 Icon="@(new FileImageSource { File="paw.png" })">
+                 Icon="@Paw">
                 <ShellContent Route="cats"
                               Title="Cats"
-                              Icon="@(new FileImageSource { File="cat.png" })">
+                              Icon="@Cat">
                     <CatsPage />
                 </ShellContent>
 
                 <ShellContent Route="dogs"
                               Title="Dogs"
-                              Icon="@(new FileImageSource { File="dog.png" })">
+                              Icon="@Dog">
                     <DogsPage />
                 </ShellContent>
             </Tab>
 
             <ShellContent Route="monkeys"
                           Title="Monkeys"
-                          Icon="@(new FileImageSource { File="monkey.png" })">
+                          Icon="@Monkey">
                 <MonkeysPage />
             </ShellContent>
 
             <ShellContent Route="elephants"
                           Title="Elephants"
-                          Icon="@(new FileImageSource { File="elephant.png" })">
+                          Icon="@Elephant">
                 <ElephantsPage />
             </ShellContent>
 
             <ShellContent Route="bears"
                           Title="Bears"
-                          Icon="@(new FileImageSource { File="bear.png" })">
+                          Icon="@Bear">
                 <BearsPage />
             </ShellContent>
         </FlyoutItem>
 
         <ShellContent Route="about"
                       Title="About"
-                      Icon="@(new FileImageSource { File="info.png" })">
+                      Icon="@Info">
             <AboutPage />
         </ShellContent>
 
         <MenuItem Text="Random"
-                  IconImageSource="@(new FileImageSource { File="random.png" })"
+                  IconImageSource="@Random"
                   OnClick="OnRandomClick" />
         <MenuItem Text="Help"
-                  IconImageSource="@(new FileImageSource { File="help.png" })"
+                  IconImageSource="@Help"
                   OnClick="OnHelpClick" />
     </ChildContent>
 </Shell>
 
 @code
 {
+    ImageSource Photo = new FileImageSource { File = "photo.png" };
+    ImageSource Paw = new FileImageSource { File = "paw.png" };
+    ImageSource Cat = new FileImageSource { File = "cat.png" };
+    ImageSource Dog = new FileImageSource { File = "dog.png" };
+    ImageSource Monkey = new FileImageSource { File = "monkey.png" };
+    ImageSource Elephant = new FileImageSource { File = "elephant.png" };
+    ImageSource Bear = new FileImageSource { File = "bear.png" };
+    ImageSource Info = new FileImageSource { File = "info.png" };
+    ImageSource Random = new FileImageSource { File = "random.png" };
+    ImageSource Help = new FileImageSource { File = "help.png" };
+
     void OnNavigated(ShellNavigatedEventArgs e)
     {
     }

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/AnimalTemplate.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/AnimalTemplate.razor
@@ -1,7 +1,7 @@
-﻿<Grid Padding="new Thickness(10)" RowDefinitions="Auto, Auto" ColumnDefinitions="Auto, *">
-    <TapGestureRecognizer OnTapped="Details"/>
+﻿<Grid Padding="10" RowDefinitions="Auto, Auto" ColumnDefinitions="Auto, *">
+    <TapGestureRecognizer OnTapped="Details" />
     <GridCell RowSpan="2">
-        <Image Source="new UriImageSource { Uri=new Uri(Animal.ImageUrl) }"
+        <Image Source="imageSource"
                Aspect="Aspect.AspectFill"
                HeightRequest="60"
                WidthRequest="60" />
@@ -23,10 +23,19 @@
 @code
 {
     [Parameter] public Animal Animal { get; set; }
-    [Parameter] public EventCallback<Animal> OnClick {get; set; }
+    [Parameter] public EventCallback<Animal> OnClick { get; set; }
+
+    UriImageSource imageSource = new UriImageSource();
+
+    protected override void OnParametersSet()
+    {
+        var uri = new Uri(Animal.ImageUrl);
+        imageSource.Uri = uri;
+    }
+
     void Details()
     {
-        if(OnClick.HasDelegate)
+        if (OnClick.HasDelegate)
             OnClick.InvokeAsync(Animal);
     }
 }

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/BearsPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/BearsPage.razor
@@ -1,14 +1,11 @@
 ﻿@inject ShellNavigationManager NavigationManager
 
 <ContentPage>
-    <ScrollView>
-        <StackLayout>
-            @foreach (var animal in BearData.Bears)
-            {
-                <AnimalTemplate Animal="animal" OnClick="AnimalClicked"></AnimalTemplate>
-            }
-        </StackLayout>
-    </ScrollView>
+    <CollectionView ItemsSource="BearData.Bears">
+        <ItemTemplate>
+            <AnimalTemplate Animal="context" OnClick="AnimalClicked" />
+        </ItemTemplate>
+    </CollectionView>
 </ContentPage>
 
 

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/CatsPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/CatsPage.razor
@@ -1,13 +1,10 @@
 ﻿@inject ShellNavigationManager NavigationManager
 <ContentPage>
-    <ScrollView>
-        <StackLayout>
-            @foreach (var animal in CatData.Cats)
-            {
-                <AnimalTemplate Animal="animal" OnClick="AnimalClicked" />
-            }
-        </StackLayout>
-    </ScrollView>
+    <CollectionView ItemsSource="CatData.Cats">
+        <ItemTemplate>
+            <AnimalTemplate Animal="context" OnClick="AnimalClicked" />
+        </ItemTemplate>
+    </CollectionView>
 </ContentPage>
 
 

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/DogsPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/DogsPage.razor
@@ -1,13 +1,10 @@
 ﻿@inject ShellNavigationManager NavigationManager
 <ContentPage>
-    <ScrollView>
-        <StackLayout>
-            @foreach (var animal in DogData.Dogs)
-            {
-                <AnimalTemplate Animal="animal" OnClick="AnimalClicked" />
-            }
-        </StackLayout>
-    </ScrollView>
+    <CollectionView ItemsSource="DogData.Dogs">
+        <ItemTemplate>
+            <AnimalTemplate Animal="@context" OnClick="AnimalClicked" />
+        </ItemTemplate>
+    </CollectionView>
 </ContentPage>
 
 @code {

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/ElephantsPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/ElephantsPage.razor
@@ -1,14 +1,11 @@
 ﻿@inject ShellNavigationManager NavigationManager
 
 <ContentPage>
-    <ScrollView>
-        <StackLayout>
-            @foreach (var animal in ElephantData.Elephants)
-            {
-                <AnimalTemplate Animal="animal" OnClick="AnimalClicked" />
-            }
-        </StackLayout>
-    </ScrollView>
+    <CollectionView ItemsSource="ElephantData.Elephants">
+        <ItemTemplate>
+            <AnimalTemplate Animal="context" OnClick="AnimalClicked" />
+        </ItemTemplate>
+    </CollectionView>
 </ContentPage>
 
 @code {

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/MonkeysPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/MonkeysPage.razor
@@ -1,13 +1,10 @@
 ﻿@inject ShellNavigationManager NavigationManager
 <ContentPage>
-    <ScrollView>
-        <StackLayout>
-            @foreach (var animal in MonkeyData.Monkeys)
-            {
-                <AnimalTemplate Animal="animal" OnClick="AnimalClicked" />
-            }
-        </StackLayout>
-    </ScrollView>
+    <CollectionView ItemsSource="MonkeyData.Monkeys">
+        <ItemTemplate>
+            <AnimalTemplate Animal="context" OnClick="AnimalClicked" />
+        </ItemTemplate>
+    </CollectionView>
 </ContentPage>
 
 @code {

--- a/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
+++ b/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
@@ -116,6 +116,8 @@ namespace ComponentWrapperGenerator
         {{
             ElementHandlerRegistry.RegisterElementHandler<{componentName}>(
                 renderer => new {componentHandlerName}(renderer, new {componentNamespacePrefix}{componentName}()));
+
+            RegisterAdditionalHandlers();
         }}
 ";
             }
@@ -140,6 +142,8 @@ namespace {Settings.RootNamespace}
         }}
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }}
 }}
 ");

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -5,6 +5,7 @@ BaseShellItem
 BoxView
 Button
 CheckBox
+#CollectionView // Manually written to use custom logic for generics and binding
 ContentPage
 ContentView
 DatePicker
@@ -15,10 +16,12 @@ FlyoutItem
 Frame
 GestureElement
 Grid
+#GroupableItemsView // Manually written to use custom logic for generics and binding
 #GridCell // Not based on real XF type
 Image
 ImageButton
 InputView
+#ItemsView // Manually written to use custom logic for generics and binding
 Label
 Layout
 #FlyoutDetailPage // Not based on real XF type
@@ -31,6 +34,7 @@ Page
 #Picker // Manually written to use custom logic for generics and binding
 ProgressBar
 ScrollView
+#SelectableItemsView // Manually written to use custom logic for generics and binding
 Shell
 ShellContent
 #ShellFlyoutHeader // Not based on real XF type
@@ -41,6 +45,7 @@ Slider
 Span
 StackLayout
 Stepper
+#StructuredItemsView  // Manually written to use custom logic for generics and binding
 #StyleSheet // Not based on real XF type
 Switch
 Tab

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -49,6 +49,7 @@ TabbedPage
 TemplatedPage
 TemplatedView
 TimePicker
+ToolbarItem
 View
 VisualElement
 

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerFactory.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerFactory.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.AspNetCore.Components;
 using System;
 
 namespace Microsoft.MobileBlazorBindings.Core
 {
     internal class ElementHandlerFactory
     {
-        private readonly Func<NativeComponentRenderer, IElementHandler, IElementHandler> _callback;
+        private readonly Func<NativeComponentRenderer, IElementHandler, IComponent, IElementHandler> _callback;
 
-        public ElementHandlerFactory(Func<NativeComponentRenderer, IElementHandler, IElementHandler> callback)
+        public ElementHandlerFactory(Func<NativeComponentRenderer, IElementHandler, IComponent, IElementHandler> callback)
         {
             _callback = callback ?? throw new ArgumentNullException(nameof(callback));
         }
 
         public IElementHandler CreateElementHandler(ElementHandlerFactoryContext context)
         {
-            return _callback(context.Renderer, context.ParentHandler);
+            return _callback(context.Renderer, context.ParentHandler, context.Component);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerFactoryContext.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerFactoryContext.cs
@@ -1,20 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.AspNetCore.Components;
 using System;
 
 namespace Microsoft.MobileBlazorBindings.Core
 {
     internal class ElementHandlerFactoryContext
     {
-        public ElementHandlerFactoryContext(NativeComponentRenderer renderer, IElementHandler parentHandler)
+        public ElementHandlerFactoryContext(NativeComponentRenderer renderer, IElementHandler parentHandler, IComponent component)
         {
             Renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
             ParentHandler = parentHandler;
+            Component = component;
         }
 
         public IElementHandler ParentHandler { get; }
-
+        public IComponent Component { get; }
         public NativeComponentRenderer Renderer { get; }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerRegistry.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerRegistry.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
 
@@ -12,22 +13,35 @@ namespace Microsoft.MobileBlazorBindings.Core
             = new Dictionary<string, ElementHandlerFactory>();
 
         public static void RegisterElementHandler<TComponent>(
+            Func<NativeComponentRenderer, IElementHandler, TComponent, IElementHandler> factory) where TComponent : NativeControlComponentBase
+        {
+            ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory((renderer, parent, component) => factory(renderer, parent, (TComponent)component)));
+        }
+
+        public static void RegisterElementHandler<TComponent>(
             Func<NativeComponentRenderer, IElementHandler, IElementHandler> factory) where TComponent : NativeControlComponentBase
         {
-            ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory(factory));
+            ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory((renderer, parent, _) => factory(renderer, parent)));
         }
 
         public static void RegisterElementHandler<TComponent>(
             Func<NativeComponentRenderer, IElementHandler> factory) where TComponent : NativeControlComponentBase
         {
-            ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory((renderer, _) => factory(renderer)));
+            ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory((renderer, _, __) => factory(renderer)));
         }
 
         public static void RegisterPropertyContentHandler<TComponent>(string propertyName,
             Func<NativeComponentRenderer, IElementHandler> factory) where TComponent : NativeControlComponentBase
         {
             var key = $"p-{typeof(TComponent).FullName}.{propertyName}";
-            ElementHandlers.Add(key, new ElementHandlerFactory((renderer, _) => factory(renderer)));
+            ElementHandlers.Add(key, new ElementHandlerFactory((renderer, _, __) => factory(renderer)));
+        }
+
+        public static void RegisterPropertyContentHandler<TComponent>(string propertyName,
+            Func<NativeComponentRenderer, IElementHandler, IComponent, IElementHandler> factory) where TComponent : NativeControlComponentBase
+        {
+            var key = $"p-{typeof(TComponent).FullName}.{propertyName}";
+            ElementHandlers.Add(key, new ElementHandlerFactory((renderer, parent, component) => factory(renderer, parent, component)));
         }
 
         public static void RegisterElementHandler<TComponent, TControlHandler>() where TComponent : NativeControlComponentBase where TControlHandler : class, IElementHandler, new()

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerRegistry.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementHandlerRegistry.cs
@@ -23,6 +23,13 @@ namespace Microsoft.MobileBlazorBindings.Core
             ElementHandlers.Add(typeof(TComponent).FullName, new ElementHandlerFactory((renderer, _) => factory(renderer)));
         }
 
+        public static void RegisterPropertyContentHandler<TComponent>(string propertyName,
+            Func<NativeComponentRenderer, IElementHandler> factory) where TComponent : NativeControlComponentBase
+        {
+            var key = $"p-{typeof(TComponent).FullName}.{propertyName}";
+            ElementHandlers.Add(key, new ElementHandlerFactory((renderer, _) => factory(renderer)));
+        }
+
         public static void RegisterElementHandler<TComponent, TControlHandler>() where TComponent : NativeControlComponentBase where TControlHandler : class, IElementHandler, new()
         {
             RegisterElementHandler<TComponent>((_, __) => new TControlHandler());

--- a/src/Microsoft.MobileBlazorBindings.Core/NativeComponentAdapter.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/NativeComponentAdapter.cs
@@ -250,7 +250,7 @@ namespace Microsoft.MobileBlazorBindings.Core
             ref var frame = ref frames[frameIndex];
             var elementName = frame.ElementName;
             var elementHandlerFactory = ElementHandlerRegistry.ElementHandlers[elementName];
-            var elementHandler = elementHandlerFactory.CreateElementHandler(new ElementHandlerFactoryContext(Renderer, _closestPhysicalParent));
+            var elementHandler = elementHandlerFactory.CreateElementHandler(new ElementHandlerFactoryContext(Renderer, _closestPhysicalParent, _targetComponent));
 
             if (_targetComponent is NativeControlComponentBase componentInstance)
             {

--- a/src/Microsoft.MobileBlazorBindings.Core/NativeControlComponentBase.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/NativeControlComponentBase.cs
@@ -32,10 +32,17 @@ namespace Microsoft.MobileBlazorBindings.Core
                 builder.AddContent(2, childContent);
             }
 
+            int sequence = 3;
+            RenderAdditionalElementContent(builder, ref sequence);
+
             builder.CloseElement();
         }
 
         protected virtual void RenderAttributes(AttributesBuilder builder)
+        {
+        }
+
+        protected virtual void RenderAdditionalElementContent(RenderTreeBuilder builder, ref int sequence)
         {
         }
 

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.generated.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TwoPaneView>(
                 renderer => new TwoPaneViewHandler(renderer, new XFD.TwoPaneView()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? MinTallModeHeight { get; set; }
@@ -65,5 +67,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ActivityIndicator.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ActivityIndicator.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ActivityIndicator>(
                 renderer => new ActivityIndicatorHandler(renderer, new XF.ActivityIndicator()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseMenuItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseMenuItem.generated.cs
@@ -23,5 +23,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<BaseShellItem>(
                 renderer => new BaseShellItemHandler(renderer, new XF.BaseShellItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -116,5 +118,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BoxView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BoxView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<BoxView>(
                 renderer => new BoxViewHandler(renderer, new XF.BoxView()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Button.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Button.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Button>(
                 renderer => new ButtonHandler(renderer, new XF.Button()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -137,5 +139,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<CheckBox>(
                 renderer => new CheckBoxHandler(renderer, new XF.CheckBox()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.Color? Color { get; set; }
@@ -39,5 +41,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/CollectionView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/CollectionView.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public class CollectionView<T> : GroupableItemsView<T>
+    {
+        static CollectionView()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<CollectionView<T>>(
+                renderer => new CollectionViewHandler(renderer, new XF.CollectionView()));
+        }
+
+        public new XF.CollectionView NativeControl => ((CollectionViewHandler)ElementHandler).CollectionViewControl;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ContentPage>(
                 renderer => new ContentPageHandler(renderer, new XF.ContentPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ContentPage NativeControl => ((ContentPageHandler)ElementHandler).ContentPageControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ContentView>(
                 renderer => new ContentViewHandler(renderer, new XF.ContentView()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ContentView NativeControl => ((ContentViewHandler)ElementHandler).ContentViewControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/DataTemplateItemComponent.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/DataTemplateItemComponent.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.DataTemplates
+{
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Class is used as generic parameter.
+    internal class DataTemplateItemComponent<T> : ComponentBase
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        private XF.ContentView _contentView;
+        private object _item;
+
+        [Parameter] public RenderFragment<T> Template { get; set; }
+
+        [Parameter]
+        public XF.ContentView ContentView
+        {
+            get
+            {
+                return _contentView;
+            }
+            set
+            {
+                if (_contentView != null && _contentView != value)
+                {
+                    throw new NotSupportedException("Cannot re-assign ContentView after being originally set.");
+                }
+
+                _contentView = value;
+                OnContentViewSet();
+            }
+        }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            if (_item != null)
+            {
+                builder.AddContent(0, Template.Invoke((T)_item));
+            }
+        }
+
+        private void OnContentViewSet()
+        {
+            _item = ContentView.BindingContext;
+
+            ContentView.BindingContextChanged += (_, __) =>
+            {
+                if (ContentView.BindingContext != null && _item != ContentView.BindingContext)
+                {
+                    _item = ContentView.BindingContext;
+                    StateHasChanged();
+                }
+            };
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/DataTemplateItemsComponent.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/DataTemplateItemsComponent.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using System.Collections.Generic;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.DataTemplates
+{
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Class is used as generic parameter.
+    internal class DataTemplateItemsComponent<T> : ComponentBase
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, ElementName);
+
+            foreach (var itemRoot in _itemRoots)
+            {
+                builder.OpenComponent<InitializedContentView>(1);
+
+                builder.AddAttribute(2, nameof(InitializedContentView.NativeControl), itemRoot);
+                builder.AddAttribute(3, "ChildContent", (RenderFragment)(builder =>
+                {
+                    builder.OpenComponent<DataTemplateItemComponent<T>>(4);
+                    builder.AddAttribute(5, nameof(DataTemplateItemComponent<T>.ContentView), itemRoot);
+                    builder.AddAttribute(6, nameof(DataTemplateItemComponent<T>.Template), Template);
+                    builder.CloseComponent();
+                }));
+
+                builder.CloseComponent();
+            }
+
+            builder.CloseElement();
+        }
+
+        // ElementName is parametrized so that component would be handled by appropriate handler.
+        [Parameter] public string ElementName { get; set; }
+        [Parameter] public RenderFragment<T> Template { get; set; }
+
+        private readonly List<XF.ContentView> _itemRoots = new List<XF.ContentView>();
+
+        public void Add(XF.ContentView templateRoot)
+        {
+            _itemRoots.Add(templateRoot);
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/InitializedContentView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/InitializedContentView.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.DataTemplates
+{
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Class is used as generic parameter.
+    internal class InitializedContentView : ContentView
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [Parameter] public new XF.ContentView NativeControl { get; set; }
+
+        static InitializedContentView()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<InitializedContentView>(
+                (renderer, _, component) => new ContentViewHandler(renderer, component.NativeControl));
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/MbbDataTemplate.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/DataTemplates/MbbDataTemplate.cs
@@ -1,0 +1,17 @@
+﻿using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.DataTemplates
+{
+    internal class MbbDataTemplate<T> : XF.DataTemplate
+    {
+        public MbbDataTemplate(DataTemplateItemsComponent<T> dataTemplateItemsAccessor)
+            : base(() =>
+            {
+                var contentView = new XF.ContentView();
+                dataTemplateItemsAccessor.Add(contentView);
+                return contentView;
+            })
+        {
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/DatePicker.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/DatePicker.generated.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<DatePicker>(
                 renderer => new DatePickerHandler(renderer, new XF.DatePicker()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? CharacterSpacing { get; set; }
@@ -119,5 +121,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Entry.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Entry.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Entry>(
                 renderer => new EntryHandler(renderer, new XF.Entry()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.ClearButtonVisibility? ClearButtonVisibility { get; set; }
@@ -126,5 +128,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/FlyoutItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FlyoutItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<FlyoutItem>(
                 renderer => new FlyoutItemHandler(renderer, new XF.FlyoutItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.FlyoutItem NativeControl => ((FlyoutItemHandler)ElementHandler).FlyoutItemControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/FlyoutPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FlyoutPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<FlyoutPage>(
                 renderer => new FlyoutPageHandler(renderer, new XF.FlyoutPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.FlyoutLayoutBehavior? FlyoutLayoutBehavior { get; set; }
@@ -44,5 +46,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Frame.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Frame.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Frame>(
                 renderer => new FrameHandler(renderer, new XF.Frame()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -59,5 +61,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/GestureElement.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/GestureElement.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<GestureElement>(
                 renderer => new GestureElementHandler(renderer, new XF.GestureElement()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.GestureElement NativeControl => ((GestureElementHandler)ElementHandler).GestureElementControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Grid.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Grid.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Grid>(
                 renderer => new GridHandler(renderer, new XF.Grid()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/GroupableItemsView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/GroupableItemsView.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public abstract class GroupableItemsView<T> : SelectableItemsView<T>
+    {
+        // Grouping is not supported at this moment
+        // [Parameter] public bool? IsGrouped { get; set; }
+
+        public new XF.GroupableItemsView NativeControl => ((GroupableItemsViewHandler)ElementHandler).GroupableItemsViewControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            //if (IsGrouped != null)
+            //{
+            //    builder.AddAttribute(nameof(IsGrouped), IsGrouped.Value);
+            //}
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CollectionViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CollectionViewHandler.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class CollectionViewHandler : GroupableItemsViewHandler
+    {
+        public CollectionViewHandler(NativeComponentRenderer renderer, XF.CollectionView collectionViewControl) : base(renderer, collectionViewControl)
+        {
+            CollectionViewControl = collectionViewControl ?? throw new ArgumentNullException(nameof(collectionViewControl));
+        }
+
+        public XF.CollectionView CollectionViewControl { get; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPropertyHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPropertyHandler.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class ContentPropertyHandler<TElementType> : IXamarinFormsContainerElementHandler, INonChildContainerElement
+    {
+        private readonly Action<TElementType, XF.Element> _setPropertyAction;
+        private TElementType _parent;
+
+        public ContentPropertyHandler(Action<TElementType, XF.Element> setPropertyAction)
+        {
+            _setPropertyAction = setPropertyAction;
+        }
+
+        public void SetParent(object parentElement)
+        {
+            _parent = (TElementType)parentElement;
+        }
+
+        void IXamarinFormsContainerElementHandler.AddChild(XF.Element child, int physicalSiblingIndex)
+        {
+            _setPropertyAction(_parent, child);
+        }
+
+        int IXamarinFormsContainerElementHandler.GetChildIndex(XF.Element child)
+        {
+            return -1;
+        }
+
+        void IXamarinFormsContainerElementHandler.RemoveChild(XF.Element child)
+        {
+            _setPropertyAction(_parent, null);
+        }
+
+        // Because this is a 'fake' element, all matters related to physical trees
+        // should be no-ops.
+
+        object IElementHandler.TargetElement => null;
+        void IElementHandler.ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName) { }
+
+        XF.Element IXamarinFormsElementHandler.ElementControl => null;
+        bool IXamarinFormsElementHandler.IsParented() => false;
+        bool IXamarinFormsElementHandler.IsParentedTo(XF.Element parent) => false;
+
+        void IXamarinFormsElementHandler.SetParent(XF.Element parent)
+        {
+            // This should never get called. Instead, INonChildContainerElement.SetParent() implemented
+            // in this class should get called.
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/DataTemplatePropertyHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/DataTemplatePropertyHandler.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.DataTemplates;
+using System;
+using Xamarin.Forms;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class DataTemplatePropertyHandler<TElementType, TItemType> : IXamarinFormsContainerElementHandler, INonChildContainerElement
+    {
+        private readonly DataTemplateItemsComponent<TItemType> _dataTemplateItemsComponent;
+        private readonly Action<TElementType, DataTemplate> _setPropertyAction;
+
+        public DataTemplatePropertyHandler(IComponent dataTemplateItemsComponent, Action<TElementType, DataTemplate> setPropertyAction)
+        {
+            _dataTemplateItemsComponent = (DataTemplateItemsComponent<TItemType>)dataTemplateItemsComponent;
+            _setPropertyAction = setPropertyAction;
+        }
+
+        public void SetParent(object parentElement)
+        {
+            var parent = (TElementType)parentElement;
+            var dataTemplate = new MbbDataTemplate<TItemType>(_dataTemplateItemsComponent);
+            _setPropertyAction(parent, dataTemplate);
+        }
+
+        // Because this is a 'fake' element, all matters related to physical trees
+        // should be no-ops.
+
+        void IXamarinFormsContainerElementHandler.AddChild(XF.Element child, int physicalSiblingIndex) { }
+
+        void IXamarinFormsContainerElementHandler.RemoveChild(XF.Element child) { }
+
+        int IXamarinFormsContainerElementHandler.GetChildIndex(XF.Element child) => -1;
+
+        object IElementHandler.TargetElement => null;
+        void IElementHandler.ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName) { }
+
+        XF.Element IXamarinFormsElementHandler.ElementControl => null;
+        bool IXamarinFormsElementHandler.IsParented() => false;
+        bool IXamarinFormsElementHandler.IsParentedTo(XF.Element parent) => false;
+
+        void IXamarinFormsElementHandler.SetParent(XF.Element parent)
+        {
+            // This should never get called. Instead, INonChildContainerElement.SetParent() implemented
+            // in this class should get called.
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GroupableItemsViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GroupableItemsViewHandler.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class GroupableItemsViewHandler : SelectableItemsViewHandler
+    {
+        public GroupableItemsViewHandler(NativeComponentRenderer renderer, XF.GroupableItemsView groupableItemsViewControl) : base(renderer, groupableItemsViewControl)
+        {
+            GroupableItemsViewControl = groupableItemsViewControl ?? throw new ArgumentNullException(nameof(groupableItemsViewControl));
+        }
+
+        public XF.GroupableItemsView GroupableItemsViewControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.GroupableItemsView.IsGrouped):
+                    GroupableItemsViewControl.IsGrouped = AttributeHelper.GetBool(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ItemsViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ItemsViewHandler.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using System.Collections;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public abstract class ItemsViewHandler : ViewHandler
+    {
+        public ItemsViewHandler(NativeComponentRenderer renderer, XF.ItemsView itemsViewControl) : base(renderer, itemsViewControl)
+        {
+            ItemsViewControl = itemsViewControl ?? throw new ArgumentNullException(nameof(itemsViewControl));
+
+            InitializeEventHandlers(renderer);
+        }
+        public XF.ItemsView ItemsViewControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.ItemsView.HorizontalScrollBarVisibility):
+                    ItemsViewControl.HorizontalScrollBarVisibility = (XF.ScrollBarVisibility)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ItemsView.ItemsUpdatingScrollMode):
+                    ItemsViewControl.ItemsUpdatingScrollMode = (XF.ItemsUpdatingScrollMode)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ItemsView.RemainingItemsThreshold):
+                    ItemsViewControl.RemainingItemsThreshold = AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ItemsView.VerticalScrollBarVisibility):
+                    ItemsViewControl.VerticalScrollBarVisibility = (XF.ScrollBarVisibility)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ItemsView.ItemsSource):
+                    ItemsViewControl.ItemsSource = AttributeHelper.DelegateToObject<IEnumerable>(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+
+        private void InitializeEventHandlers(NativeComponentRenderer renderer)
+        {
+            ConfigureEvent(
+                eventName: "onremainingitemsthresholdreached",
+                setId: id => RemainingItemsThresholdReachedEventHandlerId = id,
+                clearId: id => { if (RemainingItemsThresholdReachedEventHandlerId == id) { RemainingItemsThresholdReachedEventHandlerId = 0; } });
+            ItemsViewControl.RemainingItemsThresholdReached += (s, e) =>
+            {
+                if (RemainingItemsThresholdReachedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(RemainingItemsThresholdReachedEventHandlerId, null, e));
+                }
+            };
+
+            ConfigureEvent(
+                eventName: "onscrolled",
+                setId: id => ScrolledEventHandlerId = id,
+                clearId: id => { if (ScrolledEventHandlerId == id) { ScrolledEventHandlerId = 0; } });
+            ItemsViewControl.Scrolled += (s, e) =>
+            {
+                if (ScrolledEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ScrolledEventHandlerId, null, e));
+                }
+            };
+
+            ConfigureEvent(
+                eventName: "onscrolltorequested",
+                setId: id => ScrollToRequestedEventHandlerId = id,
+                clearId: id => { if (ScrollToRequestedEventHandlerId == id) { ScrollToRequestedEventHandlerId = 0; } });
+            ItemsViewControl.ScrollToRequested += (s, e) =>
+            {
+                if (ScrollToRequestedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ScrollToRequestedEventHandlerId, null, e));
+                }
+            };
+        }
+
+        public ulong RemainingItemsThresholdReachedEventHandlerId { get; set; }
+        public ulong ScrolledEventHandlerId { get; set; }
+        public ulong ScrollToRequestedEventHandlerId { get; set; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ListContentPropertyHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ListContentPropertyHandler.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using System.Collections.Generic;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class ListContentPropertyHandler<TElementType, TItemType> : IXamarinFormsContainerElementHandler, INonChildContainerElement where TItemType : XF.Element
+    {
+        private readonly Func<TElementType, IList<TItemType>> _listPropertyAccessor;
+        private IList<TItemType> _propertyItems;
+
+        public ListContentPropertyHandler(Func<TElementType, IList<TItemType>> listPropertyAccessor)
+        {
+            _listPropertyAccessor = listPropertyAccessor;
+        }
+
+        public void SetParent(object parentElement)
+        {
+            _propertyItems = _listPropertyAccessor((TElementType)parentElement);
+        }
+
+        void IXamarinFormsContainerElementHandler.AddChild(XF.Element child, int physicalSiblingIndex)
+        {
+            if (!(child is TItemType typedChild))
+            {
+                throw new NotSupportedException($"Cannot add item of type {child?.GetType().Name} to a {typeof(TItemType)} collection.");
+            }
+
+            _propertyItems.Insert(physicalSiblingIndex, typedChild);
+        }
+
+        int IXamarinFormsContainerElementHandler.GetChildIndex(XF.Element child)
+        {
+            return _propertyItems.IndexOf(child as TItemType);
+        }
+
+        void IXamarinFormsContainerElementHandler.RemoveChild(XF.Element child)
+        {
+            _propertyItems.Remove(child as TItemType);
+        }
+
+        // Because this is a 'fake' element, all matters related to physical trees
+        // should be no-ops.
+
+        object IElementHandler.TargetElement => null;
+        void IElementHandler.ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName) { }
+
+        XF.Element IXamarinFormsElementHandler.ElementControl => null;
+        bool IXamarinFormsElementHandler.IsParented() => false;
+        bool IXamarinFormsElementHandler.IsParentedTo(XF.Element parent) => false;
+
+        void IXamarinFormsElementHandler.SetParent(XF.Element parent)
+        {
+            // This should never get called. Instead, INonChildContainerElement.SetParent() implemented
+            // in this class should get called.
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SelectableItemsViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SelectableItemsViewHandler.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class SelectableItemsViewHandler : StructuredItemsViewHandler
+    {
+        public SelectableItemsViewHandler(NativeComponentRenderer renderer, XF.SelectableItemsView selectableItemsViewControl) : base(renderer, selectableItemsViewControl)
+        {
+            SelectableItemsViewControl = selectableItemsViewControl ?? throw new ArgumentNullException(nameof(selectableItemsViewControl));
+            InitializeEventHandlers(renderer);
+        }
+
+        public XF.SelectableItemsView SelectableItemsViewControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.SelectableItemsView.SelectedItem):
+                    SelectableItemsViewControl.SelectedItem = AttributeHelper.DelegateToObject<object>(attributeValue);
+                    break;
+                case nameof(XF.SelectableItemsView.SelectedItems):
+                    // Don't assign value if lists content is equal. Otherwise leads to infinite loop when binded. 
+                    var listValue = AttributeHelper.DelegateToObject<IList<object>>(attributeValue);
+                    if (!Enumerable.SequenceEqual(listValue, SelectableItemsViewControl.SelectedItems))
+                    {
+                        SelectableItemsViewControl.SelectedItems = listValue;
+                    }
+                    break;
+                case nameof(XF.SelectableItemsView.SelectionMode):
+                    SelectableItemsViewControl.SelectionMode = (XF.SelectionMode)AttributeHelper.GetInt(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+
+        private void InitializeEventHandlers(NativeComponentRenderer renderer)
+        {
+            ConfigureEvent(
+                eventName: "onselectionchanged",
+                setId: id => SelectionChangedEventHandlerId = id,
+                clearId: id => { if (SelectionChangedEventHandlerId == id) { SelectionChangedEventHandlerId = 0; } });
+
+            ConfigureEvent(
+                eventName: "onselecteditemchanged",
+                setId: id => SelectedItemChangedEventHandlerId = id,
+                clearId: id => { if (SelectedItemChangedEventHandlerId == id) { SelectedItemChangedEventHandlerId = 0; } });
+
+            ConfigureEvent(
+                eventName: "onselecteditemschanged",
+                setId: id => SelectedItemsChangedEventHandlerId = id,
+                clearId: id => { if (SelectedItemsChangedEventHandlerId == id) { SelectedItemsChangedEventHandlerId = 0; } });
+
+            SelectableItemsViewControl.SelectionChanged += (s, e) =>
+            {
+                if (SelectionChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(SelectionChangedEventHandlerId, null, e));
+                }
+
+                if (SelectedItemChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(SelectedItemChangedEventHandlerId, null,
+                        new ChangeEventArgs { Value = SelectableItemsViewControl.SelectedItem }));
+                }
+
+                if (SelectedItemsChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(SelectedItemsChangedEventHandlerId, null,
+                        new ChangeEventArgs { Value = SelectableItemsViewControl.SelectedItems }));
+                }
+            };
+        }
+
+        public ulong SelectionChangedEventHandlerId { get; set; }
+        public ulong SelectedItemChangedEventHandlerId { get; set; }
+        public ulong SelectedItemsChangedEventHandlerId { get; set; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StructuredItemsViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StructuredItemsViewHandler.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class StructuredItemsViewHandler : ItemsViewHandler
+    {
+        public StructuredItemsViewHandler(NativeComponentRenderer renderer, XF.StructuredItemsView structuredItemsViewControl) : base(renderer, structuredItemsViewControl)
+        {
+            StructuredItemsViewControl = structuredItemsViewControl ?? throw new ArgumentNullException(nameof(structuredItemsViewControl));
+        }
+
+        public XF.StructuredItemsView StructuredItemsViewControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.StructuredItemsView.ItemSizingStrategy):
+                    StructuredItemsViewControl.ItemSizingStrategy = (XF.ItemSizingStrategy)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.StructuredItemsView.ItemsLayout):
+                    StructuredItemsViewControl.ItemsLayout = AttributeHelper.DelegateToObject<XF.IItemsLayout>(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ToolbarItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ToolbarItemHandler.generated.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class ToolbarItemHandler : MenuItemHandler
+    {
+
+        public ToolbarItemHandler(NativeComponentRenderer renderer, XF.ToolbarItem toolbarItemControl) : base(renderer, toolbarItemControl)
+        {
+            ToolbarItemControl = toolbarItemControl ?? throw new ArgumentNullException(nameof(toolbarItemControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XF.ToolbarItem ToolbarItemControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.ToolbarItem.Order):
+                    ToolbarItemControl.Order = (XF.ToolbarItemOrder)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ToolbarItem.Priority):
+                    ToolbarItemControl.Priority = AttributeHelper.GetInt(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Image.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Image.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Image>(
                 renderer => new ImageHandler(renderer, new XF.Image()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -67,5 +69,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ImageButton>(
                 renderer => new ImageButtonHandler(renderer, new XF.ImageButton()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.Aspect? Aspect { get; set; }
@@ -64,5 +66,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/InputView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/InputView.generated.cs
@@ -125,5 +125,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ItemsView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ItemsView.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Collections.Generic;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public abstract class ItemsView<T> : View
+    {
+        static ItemsView()
+        {
+            ElementHandlerRegistry.RegisterPropertyContentHandler<ItemsView<T>>(nameof(ItemTemplate),
+                (renderer, _, component) => new DataTemplatePropertyHandler<XF.ItemsView, T>(component,
+                    (itemsView, dataTemplate) => itemsView.ItemTemplate = dataTemplate));
+
+            ElementHandlerRegistry.RegisterPropertyContentHandler<ItemsView<T>>(nameof(EmptyView),
+                renderer => new ContentPropertyHandler<XF.ItemsView>(
+                    (itemsView, valueElement) => itemsView.EmptyView = valueElement));
+        }
+
+        [Parameter] public XF.ScrollBarVisibility? HorizontalScrollBarVisibility { get; set; }
+        [Parameter] public RenderFragment<T> ItemTemplate { get; set; }
+        [Parameter] public RenderFragment EmptyView { get; set; }
+        [Parameter] public IEnumerable<T> ItemsSource { get; set; }
+        [Parameter] public XF.ItemsUpdatingScrollMode? ItemsUpdatingScrollMode { get; set; }
+        [Parameter] public int? RemainingItemsThreshold { get; set; }
+        [Parameter] public XF.ScrollBarVisibility? VerticalScrollBarVisibility { get; set; }
+
+        [Parameter] public EventCallback OnRemainingItemsThresholdReached { get; set; }
+        [Parameter] public EventCallback<XF.ItemsViewScrolledEventArgs> OnScrolled { get; set; }
+        [Parameter] public EventCallback<XF.ScrollToRequestEventArgs> OnScrollToRequested { get; set; }
+
+        public new XF.ItemsView NativeControl => ((ItemsViewHandler)ElementHandler).ItemsViewControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (HorizontalScrollBarVisibility != null)
+            {
+                builder.AddAttribute(nameof(HorizontalScrollBarVisibility), (int)HorizontalScrollBarVisibility.Value);
+            }
+            if (ItemsSource != null)
+            {
+                builder.AddAttribute(nameof(ItemsSource), AttributeHelper.ObjectToDelegate(ItemsSource));
+            }
+            if (ItemsUpdatingScrollMode != null)
+            {
+                builder.AddAttribute(nameof(ItemsUpdatingScrollMode), (int)ItemsUpdatingScrollMode.Value);
+            }
+            if (RemainingItemsThreshold != null)
+            {
+                builder.AddAttribute(nameof(RemainingItemsThreshold), RemainingItemsThreshold.Value);
+            }
+            if (VerticalScrollBarVisibility != null)
+            {
+                builder.AddAttribute(nameof(VerticalScrollBarVisibility), (int)VerticalScrollBarVisibility.Value);
+            }
+            builder.AddAttribute("onremainingitemsthresholdreached", OnRemainingItemsThresholdReached);
+            builder.AddAttribute("onscrolled", OnScrolled);
+            builder.AddAttribute("onscrolltorequested", OnScrollToRequested);
+        }
+
+        protected override void RenderAdditionalElementContent(RenderTreeBuilder builder, ref int sequence)
+        {
+            RenderTreeBuilderHelper.AddDataTemplateProperty(builder, sequence++, typeof(ItemsView<T>), nameof(ItemTemplate), ItemTemplate);
+            RenderTreeBuilderHelper.AddContentProperty(builder, sequence++, typeof(ItemsView<T>), nameof(EmptyView), EmptyView);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Label.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Label.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Label>(
                 renderer => new LabelHandler(renderer, new XF.Label()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? CharacterSpacing { get; set; }
@@ -155,5 +157,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Layout.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Layout.generated.cs
@@ -57,5 +57,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<MenuItem>(
                 renderer => new MenuItemHandler(renderer, new XF.MenuItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public string @class { get; set; }
@@ -74,5 +76,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.generated.cs
@@ -34,5 +34,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
@@ -2,12 +2,21 @@
 // Licensed under the MIT license.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public partial class Page : VisualElement
     {
+        static partial void RegisterAdditionalHandlers()
+        {
+            ElementHandlerRegistry.RegisterPropertyContentHandler<Page>(nameof(ToolbarItems),
+                _ => new ListContentPropertyHandler<XF.Page, XF.ToolbarItem>(page => page.ToolbarItems));
+        }
+
         /// <summary>
         /// Indicates that the <see cref="Xamarin.Forms.Page" /> is about to appear.
         /// </summary>
@@ -18,11 +27,18 @@ namespace Microsoft.MobileBlazorBindings.Elements
         /// </summary>
         [Parameter] public EventCallback OnDisappearing { get; set; }
 
+        [Parameter] public RenderFragment ToolbarItems { get; set; }
+
 #pragma warning disable CA1721 // Property names should not match get methods
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
         protected override RenderFragment GetChildContent() => ChildContent;
+
+        protected override void RenderAdditionalElementContent(RenderTreeBuilder builder, ref int sequence)
+        {
+            RenderTreeBuilderHelper.AddContentProperty(builder, sequence++, typeof(Page), nameof(ToolbarItems), ToolbarItems);
+        }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Page>(
                 renderer => new PageHandler(renderer, new XF.Page()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public XF.ImageSource BackgroundImageSource { get; set; }
@@ -66,5 +68,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ProgressBar.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ProgressBar.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ProgressBar>(
                 renderer => new ProgressBarHandler(renderer, new XF.ProgressBar()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/PropertyWrapperComponent.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/PropertyWrapperComponent.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    /// <summary>
+    /// The only purpose of this type is to wrap content property handler, since currently renderer does not allow 
+    /// handlers without corresponding component.
+    /// </summary>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Class is used generically.
+    internal class PropertyWrapperComponent : NativeControlComponentBase
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+    {
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            ChildContent(builder);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ScrollView>(
                 renderer => new ScrollViewHandler(renderer, new XF.ScrollView()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -59,5 +61,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/SelectableItemsView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/SelectableItemsView.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Collections.Generic;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public abstract class SelectableItemsView<T> : StructuredItemsView<T>
+    {
+        //Changing source at run time is valid behavior so do not make read only
+#pragma warning disable CA2227 // Collection properties should be read only.
+        [Parameter] public IList<object> SelectedItems { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+        [Parameter] public object SelectedItem { get; set; }
+        [Parameter] public XF.SelectionMode? SelectionMode { get; set; }
+
+        [Parameter] public EventCallback<XF.SelectionChangedEventArgs> OnSelectionChanged { get; set; }
+        [Parameter] public EventCallback<IList<object>> SelectedItemsChanged { get; set; }
+        [Parameter] public EventCallback<object> SelectedItemChanged { get; set; }
+
+        public new XF.SelectableItemsView NativeControl => ((SelectableItemsViewHandler)ElementHandler).SelectableItemsViewControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (SelectedItems != null)
+            {
+                builder.AddAttribute(nameof(SelectedItems), AttributeHelper.ObjectToDelegate(SelectedItems));
+            }
+
+            if (SelectedItem != null)
+            {
+                builder.AddAttribute(nameof(SelectedItem), AttributeHelper.ObjectToDelegate(SelectedItem));
+            }
+            if (SelectionMode != null)
+            {
+                builder.AddAttribute(nameof(SelectionMode), (int)SelectionMode.Value);
+            }
+
+            builder.AddAttribute("onselectionchanged", OnSelectionChanged);
+            builder.AddAttribute("onselecteditemchanged", EventCallback.Factory.Create<ChangeEventArgs>(this, e => SelectedItemChanged.InvokeAsync(e.Value)));
+            builder.AddAttribute("onselecteditemschanged", EventCallback.Factory.Create<ChangeEventArgs>(this, e => SelectedItemsChanged.InvokeAsync((IList<object>)e.Value)));
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Shell.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Shell.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Shell>(
                 renderer => new ShellHandler(renderer, new XF.Shell()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -97,5 +99,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellContent>(
                 renderer => new ShellContentHandler(renderer, new XF.ShellContent()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ShellContent NativeControl => ((ShellContentHandler)ElementHandler).ShellContentControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellGroupItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellGroupItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellGroupItem>(
                 renderer => new ShellGroupItemHandler(renderer, new XF.ShellGroupItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -37,5 +39,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellItem>(
                 renderer => new ShellItemHandler(renderer, new XF.ShellItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ShellItem NativeControl => ((ShellItemHandler)ElementHandler).ShellItemControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ShellSection>(
                 renderer => new ShellSectionHandler(renderer, new XF.ShellSection()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.ShellSection NativeControl => ((ShellSectionHandler)ElementHandler).ShellSectionControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Slider.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Slider.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Slider>(
                 renderer => new SliderHandler(renderer, new XF.Slider()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -100,5 +102,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Span.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Span.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Span>(
                 renderer => new SpanHandler(renderer, new XF.Span()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -114,5 +116,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<StackLayout>(
                 renderer => new StackLayoutHandler(renderer, new XF.StackLayout()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -51,5 +53,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Stepper.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Stepper.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Stepper>(
                 renderer => new StepperHandler(renderer, new XF.Stepper()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -73,5 +75,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/StructuredItemsView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/StructuredItemsView.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public abstract class StructuredItemsView<T> : ItemsView<T>
+    {
+        static StructuredItemsView()
+        {
+            ElementHandlerRegistry.RegisterPropertyContentHandler<StructuredItemsView<T>>(nameof(Header),
+                _ => new ContentPropertyHandler<XF.StructuredItemsView>((itemsView, valueElement) => itemsView.Header = valueElement));
+
+            ElementHandlerRegistry.RegisterPropertyContentHandler<StructuredItemsView<T>>(nameof(Footer),
+                _ => new ContentPropertyHandler<XF.StructuredItemsView>((itemsView, valueElement) => itemsView.Footer = valueElement));
+        }
+
+        [Parameter] public XF.ItemSizingStrategy? ItemSizingStrategy { get; set; }
+        [Parameter] public XF.IItemsLayout ItemsLayout { get; set; }
+        [Parameter] public RenderFragment Header { get; set; }
+        [Parameter] public RenderFragment Footer { get; set; }
+
+        public new XF.StructuredItemsView NativeControl => ((StructuredItemsViewHandler)ElementHandler).StructuredItemsViewControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (ItemSizingStrategy != null)
+            {
+                builder.AddAttribute(nameof(ItemSizingStrategy), (int)ItemSizingStrategy.Value);
+            }
+            if (ItemsLayout != null)
+            {
+                builder.AddAttribute(nameof(ItemsLayout), AttributeHelper.ObjectToDelegate(ItemsLayout));
+            }
+        }
+
+        protected override void RenderAdditionalElementContent(RenderTreeBuilder builder, ref int sequence)
+        {
+            base.RenderAdditionalElementContent(builder, ref sequence);
+
+            RenderTreeBuilderHelper.AddContentProperty(builder, sequence++, typeof(StructuredItemsView<T>), nameof(Header), Header);
+            RenderTreeBuilderHelper.AddContentProperty(builder, sequence++, typeof(StructuredItemsView<T>), nameof(Footer), Footer);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Switch.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Switch.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Switch>(
                 renderer => new SwitchHandler(renderer, new XF.Switch()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -53,5 +55,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Tab.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Tab.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<Tab>(
                 renderer => new TabHandler(renderer, new XF.Tab()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.Tab NativeControl => ((TabHandler)ElementHandler).TabControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TabBar.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TabBar.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TabBar>(
                 renderer => new TabBarHandler(renderer, new XF.TabBar()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.TabBar NativeControl => ((TabBarHandler)ElementHandler).TabBarControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TabbedPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TabbedPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TabbedPage>(
                 renderer => new TabbedPageHandler(renderer, new XF.TabbedPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -61,5 +63,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TemplatedPage.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TemplatedPage.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TemplatedPage>(
                 renderer => new TemplatedPageHandler(renderer, new XF.TemplatedPage()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.TemplatedPage NativeControl => ((TemplatedPageHandler)ElementHandler).TemplatedPageControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TemplatedView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TemplatedView.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TemplatedView>(
                 renderer => new TemplatedViewHandler(renderer, new XF.TemplatedView()));
+
+            RegisterAdditionalHandlers();
         }
 
         public new XF.TemplatedView NativeControl => ((TemplatedViewHandler)ElementHandler).TemplatedViewControl;
@@ -28,5 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TimePicker.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TimePicker.generated.cs
@@ -16,6 +16,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<TimePicker>(
                 renderer => new TimePickerHandler(renderer, new XF.TimePicker()));
+
+            RegisterAdditionalHandlers();
         }
 
         [Parameter] public double? CharacterSpacing { get; set; }
@@ -97,5 +99,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ToolbarItem : MenuItem
+    {
+        static ToolbarItem()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<ToolbarItem>(
+                renderer => new ToolbarItemHandler(renderer, new XF.ToolbarItem()));
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates on which of the primary, secondary, or default toolbar surfaces to display this <see cref="T:Xamarin.Forms.ToolbarItem" /> element.
+        /// </summary>
+        [Parameter] public XF.ToolbarItemOrder? Order { get; set; }
+        /// <summary>
+        /// Gets or sets the priority of this <see cref="T:Xamarin.Forms.ToolbarItem" /> element.
+        /// </summary>
+        [Parameter] public int? Priority { get; set; }
+
+        public new XF.ToolbarItem NativeControl => ((ToolbarItemHandler)ElementHandler).ToolbarItemControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (Order != null)
+            {
+                builder.AddAttribute(nameof(Order), (int)Order.Value);
+            }
+            if (Priority != null)
+            {
+                builder.AddAttribute(nameof(Priority), Priority.Value);
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ToolbarItem.generated.cs
@@ -15,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         {
             ElementHandlerRegistry.RegisterElementHandler<ToolbarItem>(
                 renderer => new ToolbarItemHandler(renderer, new XF.ToolbarItem()));
+
+            RegisterAdditionalHandlers();
         }
 
         /// <summary>
@@ -45,5 +47,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/View.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/View.generated.cs
@@ -54,5 +54,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.generated.cs
@@ -260,5 +260,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder);
+
+        static partial void RegisterAdditionalHandlers();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/RenderTreeBuilderHelper.cs
+++ b/src/Microsoft.MobileBlazorBindings/RenderTreeBuilderHelper.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.MobileBlazorBindings.Elements;
+using System;
+
+namespace Microsoft.MobileBlazorBindings
+{
+    public static class RenderTreeBuilderHelper
+    {
+        public static void AddContentProperty(RenderTreeBuilder builder, int sequence, Type containingType, string propertyName, RenderFragment content)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (content != null)
+            {
+                builder.OpenRegion(sequence);
+
+                // Content properties are handled by separate handlers, there rendered as separate child elements.
+                // Renderer does not support elements without parent components as for now,
+                // therefore adding empty parent component to workaround that.
+                builder.OpenComponent<PropertyWrapperComponent>(0);
+                builder.AddAttribute(1, "ChildContent", (RenderFragment)(builder =>
+                {
+                    builder.OpenElement(2, $"p-{containingType.FullName}.{propertyName}");
+                    builder.AddContent(3, content);
+                    builder.CloseElement();
+                }));
+                builder.CloseComponent();
+
+                builder.CloseRegion();
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/RenderTreeBuilderHelper.cs
+++ b/src/Microsoft.MobileBlazorBindings/RenderTreeBuilderHelper.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.MobileBlazorBindings.Elements;
+using Microsoft.MobileBlazorBindings.Elements.DataTemplates;
 using System;
 
 namespace Microsoft.MobileBlazorBindings
@@ -21,13 +22,13 @@ namespace Microsoft.MobileBlazorBindings
             {
                 builder.OpenRegion(sequence);
 
-                // Content properties are handled by separate handlers, there rendered as separate child elements.
+                // Content properties are handled by separate handlers, therefore rendered as separate child elements.
                 // Renderer does not support elements without parent components as for now,
                 // therefore adding empty parent component to workaround that.
                 builder.OpenComponent<PropertyWrapperComponent>(0);
                 builder.AddAttribute(1, "ChildContent", (RenderFragment)(builder =>
                 {
-                    builder.OpenElement(2, $"p-{containingType.FullName}.{propertyName}");
+                    builder.OpenElement(2, GetElementName(containingType, propertyName));
                     builder.AddContent(3, content);
                     builder.CloseElement();
                 }));
@@ -35,6 +36,32 @@ namespace Microsoft.MobileBlazorBindings
 
                 builder.CloseRegion();
             }
+        }
+
+        public static void AddDataTemplateProperty<T>(RenderTreeBuilder builder, int sequence, Type containingType, string propertyName, RenderFragment<T> template)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (containingType is null)
+            {
+                throw new ArgumentNullException(nameof(containingType));
+            }
+
+            builder.OpenRegion(sequence);
+
+            builder.OpenComponent<DataTemplateItemsComponent<T>>(0);
+            builder.AddAttribute(1, nameof(DataTemplateItemsComponent<T>.ElementName), GetElementName(containingType, propertyName));
+            builder.AddAttribute(2, nameof(DataTemplateItemsComponent<T>.Template), template);
+            builder.CloseComponent();
+
+            builder.CloseRegion();
+        }
+
+        private static string GetElementName(Type containingType, string propertyName)
+        {
+            return $"p-{containingType.FullName}.{propertyName}";
         }
     }
 }


### PR DESCRIPTION
Fixes #258 .

This PR is based on #343 , therefore that PR should be reviewed first. Reviewing commit-by-commit might be easier.
<details>
<summary>Example .razor</summary>

```razor
<ContentPage Title="Infinite scroll">
    <StackLayout>
        <CollectionView ItemsSource="_intItems"
                        RemainingItemsThreshold="2"
                        OnRemainingItemsThresholdReached="LoadItems">
            <Header>
                <Label Text="Scroll to load more items." />
            </Header>

            <ItemTemplate>
                <Item Value="@context" />
            </ItemTemplate>

            <Footer>
                <ActivityIndicator IsRunning="_loading" />
            </Footer>
        </CollectionView>
    </StackLayout>
</ContentPage>

@code {
    ObservableCollection<int> _intItems = new ObservableCollection<int>(Enumerable.Range(1, 20));
    bool _loading;

    async Task LoadItems()
    {
    ...
    }
}
```

</details>

<details>
<summary>Screen</summary>

![slDDeWRlim](https://user-images.githubusercontent.com/17177729/111088822-bb779480-8531-11eb-9e04-7a4681ad1c37.gif)

</details>

The main challenge with CollectionView is to add support for DataTemplates (represented by RenderFragment<T> in Blazor).

Small recap how CollectionView works. Using provided DataTemplate it creates enough items to fill the screen (e.g. 20). When the user scrolls the view, it reuses the same items, but updates bindings on those items to reflect other values.

Blazor does not expose any metadata for RenderFragment<T> (in fact, there is no metadata at all, RenderFragment is simply a delegate), and we cannot use XF's bindings to update displayed values directly. Therefore, I use Blazor itself to update those values.
General idea is that I render all the items created by the CollectionView (those 20 ones) to the Blazor tree. Each item is wrapped in ContentView. When CollectionView updates the ContentView's BindingContext, I update Blazor component based on this value.

The most interesting types here:
- MbbDataTemplate\<T\>
DataTemplate, which creates items, handled by Blazor.
Problem is that I cannot return actual items rendered by Blazor - because Blazor works asynchronously. Therefore I create parent ContentView element, set it as a parent for Blazor component, and return it. Actual ChildContent is populated asynchronously.

- DataTemplateItemsComponent\<T\>
This component has method Add (used by MbbDataTemplate) to add Blazor component with provided ContentView parent. And DataTemplateItemsComponent\<T\> renders a DataTemplateItemComponent\<T\> per each ContentView element in a loop.
Therefore, each time when CollectionView creates a new element from a MbbDataTemplate, this component renders additional DataTemplateItemComponent\<T\>.

- DataTemplateItemComponent\<T\>
This component holds provided RenderFragment\<T\> template. It accepts parent ContentView element, subscribes to BindingContextChanged event, and updates elements based on BindingContextValue.
Note that this component only renders anything when BindingContext is not null. I did that to avoid unnecessary updates (CollectionView sets BindingContext to null before changing it to other value for some reason), and because I wanted to avoid the requirement to handle nulls in RenderFragment\<T\> even when all items provided are not null.

- InitializedContentView
Our regular ContentView is lazy, meaning that actual XF element is created only when rendering happens (which is async). That doesn't work here, as I need to return ContentView synchronously. This component accepts XF.ContentView element as a parameter, which allows to pass already created (in MbbDataTemplate) element here.

- DataTemplatePropertyHandler
This handler creates MbbDataTemplate using rendered DataTemplateItemsComponent, and sets it to parent's property (in our case, to CollectionView.ItemTemplate).


InitializedContentViewHandler and DataTemplatePropertyHandler handlers require a reference to a Blazor component, therefore I updated NativeComponentAdapter to allow that.
