### PR TITLE
GridCell fixes

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.Core/INonPhysicalChild.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/INonPhysicalChild.cs
@@ -19,5 +19,11 @@ namespace Microsoft.MobileBlazorBindings.Core
         /// </summary>
         /// <param name="parentElement"></param>
         void SetParent(object parentElement);
+
+        /// <summary>
+        /// This is called when this component would otherwise be removed from a parent container.
+        /// This is useful so that this component can unapply its effects from parent element.
+        /// </summary>
+        void Remove();
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseAttachedPropertiesHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseAttachedPropertiesHandler.cs
@@ -15,6 +15,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         protected XF.BindableObject Target { get; private set; }
 
         public abstract void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName);
+        public abstract void Remove();
 
         public void SetParent(object parentElement)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GestureRecognizerHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GestureRecognizerHandler.cs
@@ -10,6 +10,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
     public class GestureRecognizerHandler : IXamarinFormsElementHandler, INonChildContainerElement
     {
         private readonly EventManager _eventManager = new EventManager();
+        private object _parentElement;
 
         public GestureRecognizerHandler(NativeComponentRenderer renderer, XF.GestureRecognizer gestureRecognizerControl)
         {
@@ -68,7 +69,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 throw new ArgumentNullException(nameof(parentElement));
             }
 
-            switch (parentElement)
+            _parentElement = parentElement;
+
+            switch (_parentElement)
             {
                 case XF.View view:
                     view.GestureRecognizers.Add(GestureRecognizerControl);
@@ -78,6 +81,21 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                     break;
                 default:
                     throw new InvalidOperationException($"Gesture of type {ElementControl.GetType().FullName} can't be added to parent of type {parentElement.GetType().FullName}.");
+            }
+        }
+
+        public void Remove()
+        {
+            switch (_parentElement)
+            {
+                case XF.View view:
+                    view.GestureRecognizers.Remove(GestureRecognizerControl);
+                    break;
+                case XF.GestureElement gestureElement:
+                    gestureElement.GestureRecognizers.Remove(GestureRecognizerControl);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Gesture of type {ElementControl.GetType().FullName} can't be removed from parent of type {_parentElement.GetType().FullName}.");
             }
         }
     }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridCellHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridCellHandler.cs
@@ -121,5 +121,19 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 
             _parentGrid = parentGrid;
         }
+
+        public void Remove()
+        {
+            if (_parentGrid != null)
+            {
+                foreach (var child in _children)
+                {
+                    _parentGrid.Children.Remove(child);
+                }
+
+                _children.Clear();
+                _parentGrid = null;
+            }
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridCellHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridCellHandler.cs
@@ -3,18 +3,20 @@
 
 using Microsoft.MobileBlazorBindings.Core;
 using System;
+using System.Collections.Generic;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public class GridCellHandler : IXamarinFormsContainerElementHandler, INonChildContainerElement
     {
+        private readonly List<XF.View> _children = new List<XF.View>();
+        private XF.Grid _parentGrid;
+
         public GridCellHandler(NativeComponentRenderer renderer, GridCellPlaceholderElement gridCellPlaceholderElementControl)
         {
             Renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
             GridCellPlaceholderElementControl = gridCellPlaceholderElementControl ?? throw new ArgumentNullException(nameof(gridCellPlaceholderElementControl));
-
-            _parentChildManager = new ParentChildManager<XF.Grid, XF.View>(AddChildViewToParentGrid);
         }
 
         public NativeComponentRenderer Renderer { get; }
@@ -22,12 +24,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         public XF.Element ElementControl => GridCellPlaceholderElementControl;
         public object TargetElement => ElementControl;
 
-        public int? Column { get; set; }
-        public int? ColumnSpan { get; set; }
-        public int? Row { get; set; }
-        public int? RowSpan { get; set; }
-
-        private readonly ParentChildManager<XF.Grid, XF.View> _parentChildManager;
+        public int Column { get; set; }
+        public int ColumnSpan { get; set; } = 1;
+        public int Row { get; set; }
+        public int RowSpan { get; set; } = 1;
 
         public void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
@@ -35,15 +35,19 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             {
                 case nameof(GridCell.Column):
                     Column = AttributeHelper.GetInt(attributeValue);
+                    _children.ForEach(c => XF.Grid.SetColumn(c, Column));
                     break;
                 case nameof(GridCell.ColumnSpan):
-                    ColumnSpan = AttributeHelper.GetInt(attributeValue);
+                    ColumnSpan = AttributeHelper.GetInt(attributeValue, 1);
+                    _children.ForEach(c => XF.Grid.SetColumnSpan(c, ColumnSpan));
                     break;
                 case nameof(GridCell.Row):
                     Row = AttributeHelper.GetInt(attributeValue);
+                    _children.ForEach(c => XF.Grid.SetRow(c, Row));
                     break;
                 case nameof(GridCell.RowSpan):
-                    RowSpan = AttributeHelper.GetInt(attributeValue);
+                    RowSpan = AttributeHelper.GetInt(attributeValue, 1);
+                    _children.ForEach(c => XF.Grid.SetRowSpan(c, RowSpan));
                     break;
                 default:
                     throw new NotImplementedException($"{GetType().FullName} doesn't recognize attribute '{attributeName}'");
@@ -52,20 +56,39 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 
         public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
-            _parentChildManager.SetChild(child);
+            if (!(child is XF.View childView))
+            {
+                throw new ArgumentException($"Expected parent to be of type {typeof(XF.View).FullName} but it is of type {child?.GetType().FullName}.", nameof(child));
+            }
+
+            XF.Grid.SetColumn(childView, Column);
+            XF.Grid.SetColumnSpan(childView, ColumnSpan);
+            XF.Grid.SetRow(childView, Row);
+            XF.Grid.SetRowSpan(childView, RowSpan);
+
+            _children.Add(childView);
+            _parentGrid.Children.Add(childView);
         }
 
         public void RemoveChild(XF.Element child)
         {
-            // TODO: This could probably be implemented at some point, but it isn't needed right now
-            throw new NotImplementedException();
+            if (!(child is XF.View childView))
+            {
+                throw new ArgumentException($"Expected parent to be of type {typeof(XF.View).FullName} but it is of type {child?.GetType().FullName}.", nameof(child));
+            }
+
+            _children.Remove(childView);
+            _parentGrid.Children.Remove(childView);
         }
 
         public int GetChildIndex(XF.Element child)
         {
-            // Because this is a 'fake' element, all matters related to physical trees
-            // should be no-ops.
-            return 0;
+            if (!(child is XF.View childView))
+            {
+                return -1;
+            }
+
+            return _children.IndexOf(childView);
         }
 
         public bool IsParented()
@@ -89,19 +112,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             throw new NotSupportedException();
         }
 
-        private void AddChildViewToParentGrid(ParentChildManager<XF.Grid, XF.View> parentChildManager)
-        {
-            parentChildManager.Parent.Children.Add(
-                view: parentChildManager.Child,
-                left: (Column ?? 0),
-                right: (Column ?? 0) + (ColumnSpan ?? 1),
-                top: (Row ?? 0),
-                bottom: (Row ?? 0) + (RowSpan ?? 1));
-        }
-
         public void SetParent(object parentElement)
         {
-            _parentChildManager.SetParent((XF.Element)parentElement);
+            if (!(parentElement is XF.Grid parentGrid))
+            {
+                throw new ArgumentException($"Expected parent to be of type {typeof(XF.Grid).FullName} but it is of type {parentElement?.GetType().FullName}.", nameof(parentElement));
+            }
+
+            _parentGrid = parentGrid;
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ModalContainerHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ModalContainerHandler.cs
@@ -117,5 +117,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         {
             _parentChildManager.SetParent((XF.Element)parentElement);
         }
+
+        public void Remove()
+        {
+            _parentChildManager.SetParent(null);
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellFlyoutHeaderHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellFlyoutHeaderHandler.cs
@@ -85,5 +85,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         {
             _parentChildManager.SetParent((XF.Element)parentElement);
         }
+
+        public void Remove()
+        {
+            var flyoutHeaderContentView = (XF.ContentView)_parentChildManager.Parent.FlyoutHeader;
+            flyoutHeaderContentView.IsVisible = false;
+            flyoutHeaderContentView.Content = null;
+
+            _parentChildManager.SetParent(null);
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellPropertiesHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellPropertiesHandler.cs
@@ -52,5 +52,20 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                     break;
             }
         }
+
+        public override void Remove()
+        {
+            XF.Shell.SetNavBarIsVisible(Target, (bool)XF.Shell.NavBarIsVisibleProperty.DefaultValue);
+            XF.Shell.SetNavBarHasShadow(Target, (bool)XF.Shell.NavBarHasShadowProperty.DefaultValue);
+            XF.Shell.SetTabBarIsVisible(Target, (bool)XF.Shell.NavBarHasShadowProperty.DefaultValue);
+            XF.Shell.SetBackgroundColor(Target, (XF.Color)XF.Shell.BackgroundColorProperty.DefaultValue);
+            XF.Shell.SetDisabledColor(Target, (XF.Color)XF.Shell.DisabledColorProperty.DefaultValue);
+            XF.Shell.SetForegroundColor(Target, (XF.Color)XF.Shell.ForegroundColorProperty.DefaultValue);
+            XF.Shell.SetTabBarBackgroundColor(Target, (XF.Color)XF.Shell.TabBarBackgroundColorProperty.DefaultValue);
+            XF.Shell.SetTabBarTitleColor(Target, (XF.Color)XF.Shell.TabBarTitleColorProperty.DefaultValue);
+            XF.Shell.SetTabBarUnselectedColor(Target, (XF.Color)XF.Shell.TabBarUnselectedColorProperty.DefaultValue);
+            XF.Shell.SetTitleColor(Target, (XF.Color)XF.Shell.TitleColorProperty.DefaultValue);
+            XF.Shell.SetUnselectedColor(Target, (XF.Color)XF.Shell.UnselectedColorProperty.DefaultValue);
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StyleSheetHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StyleSheetHandler.cs
@@ -100,5 +100,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 
             UpdateParentStyleSheetIfPossible();
         }
+
+        public void Remove()
+        {
+            throw new InvalidOperationException("Removing StyleSheet element is not supported.");
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
@@ -70,7 +70,11 @@ namespace Microsoft.MobileBlazorBindings
 
         protected override void RemoveChildElement(IXamarinFormsElementHandler parentHandler, IXamarinFormsElementHandler childHandler)
         {
-            if (parentHandler is IXamarinFormsContainerElementHandler parent)
+            if (childHandler is INonPhysicalChild nonPhysicalChild)
+            {
+                nonPhysicalChild.Remove();
+            }
+            else if (parentHandler is IXamarinFormsContainerElementHandler parent)
             {
                 parent.RemoveChild(childHandler.ElementControl);
             }


### PR DESCRIPTION
I've decided, that it's probably not enough pending PRs here :)

Fixes #368 .

PR contains two commits, tackling related, but separate issues.

First commit improves GridCellHandler to support removing child elements, and to support ability to change attributes (e.g. RowSpan) for existing children. It doesn't use ParentChildManager anymore, as multiple children as possible for the same grid cell.

Second commit handles the ability to remove INonPhysicalChild elements. I've added method `Remove` to that interface, and implemented it in implementations (where possible), including `GridCellHandler`.

Example:

<details>
<summary>razor</summary>

```razor
<ContentPage>
    <Grid>
        <GridCell Row="0" RowSpan="showCell ? 1 : 2">
            <Button Text="Toggle" OnClick="Toggle" />
        </GridCell>
        @if (showCell)
        {
            <GridCell Row="1">
                <Label Text="Here it is!!!" VerticalOptions="LayoutOptions.Start" />
                <Label Text="Here it is(bottom)!!!" VerticalOptions="LayoutOptions.EndAndExpand" />
            </GridCell>
        }
        <GridCell Row="3">
            <Label Text="Test" />
        </GridCell>
    </Grid>
</ContentPage>

@code
{
    bool showCell = true;

    void Toggle()
    {
        showCell = !showCell;
    }
}

```

</details>


<details>
<summary>recording</summary>

![kwVHOcFYAp](https://user-images.githubusercontent.com/17177729/119277046-10b4de00-bc26-11eb-8577-84c7116c8c5a.gif)


</details>