### PR TITLE
Update WebView2 package reference for Windows to resolve runtime error

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.WPF/Microsoft.MobileBlazorBindings.WPF.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WPF/Microsoft.MobileBlazorBindings.WPF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <UseWPF>true</UseWPF>
 

--- a/src/Microsoft.MobileBlazorBindings.WPF/Microsoft.MobileBlazorBindings.WPF.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WPF/Microsoft.MobileBlazorBindings.WPF.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.664.37" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.961.33" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/Microsoft.MobileBlazorBindings.WebView.Windows.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/Microsoft.MobileBlazorBindings.WebView.Windows.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.664.37" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.961.33" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.1874" />
     <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1874" NoWarn="NU1701" />

--- a/src/Microsoft.MobileBlazorBindings.WindowsForms/Microsoft.MobileBlazorBindings.WindowsForms.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WindowsForms/Microsoft.MobileBlazorBindings.WindowsForms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <UseWindowsForms>true</UseWindowsForms>
 

--- a/src/Microsoft.MobileBlazorBindings.WindowsForms/Microsoft.MobileBlazorBindings.WindowsForms.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WindowsForms/Microsoft.MobileBlazorBindings.WindowsForms.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.664.37" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.961.33" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Attempt to resolve failure to launch a UI built with Mobile Blazor Bindings with the latest stable release of Microsoft Edge 93.0.961.38 (Official build) (64-bit)

Resolves #403

Unfortunately, I have not succeeded in building the MobileBlazzorBindings solution on my machine, or getting the tests to run, so this update should not be considered authoritative.