### PR TITLE
Fix component governance warnings by explicitly overriding Newtonsoft.Json version

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.Authentication/Microsoft.MobileBlazorBindings.Authentication.csproj
+++ b/src/Microsoft.MobileBlazorBindings.Authentication/Microsoft.MobileBlazorBindings.Authentication.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Microsoft.MobileBlazorBindings.UnitTests/Microsoft.MobileBlazorBindings.UnitTests.csproj
+++ b/src/Microsoft.MobileBlazorBindings.UnitTests/Microsoft.MobileBlazorBindings.UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />


### PR DESCRIPTION
Longer term, it would be better to remove these two new dependencies and instead update the direct dependencies that were referencing Newtonsoft.Json 9:

 * Microsoft.NET.Test.Sdk
 * IdentityModel.OidcClient

However since that might have other consequences, I'll leave it for @Eilon to decide how to proceed.